### PR TITLE
A simple test for the keyword expansion issue (svn r5379)

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -3283,10 +3283,17 @@ def internal_co_keywords():
   kk_cvs = file(conv_cvs.get_wc('trunk', 'dir', 'kk.txt')).read()
   kv_ic = file(conv_ic.get_wc('trunk', 'dir', 'kv.txt')).read()
   kv_cvs = file(conv_cvs.get_wc('trunk', 'dir', 'kv.txt')).read()
+  # Ensure proper "/Attic" expansion of $Source$ keyword in files
+  # which are in a deleted state in trunk
+  del_ic = file(conv_ic.get_wc('branches/b', 'dir', 'kv-deleted.txt')).read()
+  del_cvs = file(conv_cvs.get_wc('branches/b', 'dir', 'kv-deleted.txt')).read()
+
 
   if ko_ic != ko_cvs:
     raise Failure()
   if kk_ic != kk_cvs:
+    raise Failure()
+  if del_ic != del_cvs:
     raise Failure()
 
   # The date format changed between cvs and co ('/' instead of '-').

--- a/test-data/internal-co-keywords-cvsrepos/dir/kv-deleted.txt,v
+++ b/test-data/internal-co-keywords-cvsrepos/dir/kv-deleted.txt,v
@@ -1,0 +1,55 @@
+head	1.2;
+branch;
+access;
+symbols
+        b:1.1.1;
+locks; strict;
+comment	@# @;
+
+
+1.2
+date	2004.07.28.10.42.27;	author kfogel;	state dead;
+branches;
+next	1.1;
+
+1.1
+date	2004.07.19.20.57.24;	author jrandom;	state Exp;
+branches 1.1.1.1;
+next	;
+
+1.1.1.1
+date	2004.07.19.20.57.25;	author jrandom;	state Exp;
+branches;
+next	;
+
+desc
+@@
+
+
+1.2
+log
+@Deleting this dreadful file
+@
+text
+@This is a fine file.
+
+This file resides at $Source$
+@
+
+
+1.1
+log
+@Add a file.
+@
+text
+@@
+
+
+1.1.1.1
+log
+@Adding a line
+@
+text
+@a1 1
+branches are fun
+@


### PR DESCRIPTION
Hi, finally put together a quick test for this. The test file consists of three commits: a base, a delete on trunk, and a branch (off base). As suggested, I added tests to internal_co_keywords verifying that both CVS and cvs2svn do the same thing on a file like this. All the tests pass (obviously including this one).
