### PR TITLE
Add some support for running `cvs2svn` under docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+build
+*-tmp
+*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# cvs2svn has some dependencies that are no longer widely available
+# (e.g., Python 2.x and an oldish version of the Subversion library).
+# This Dockerfile builds images that can be used to run or test
+# cvs2svn. Note that it is based on debian:jessie, which is pretty
+# old. But this is the most recent version of Debian where the
+# required dependencies are easily available. One way to use this is
+# to run
+#
+#     make docker-image
+#
+# to make an image for running cvs2svn, or
+#
+#     make docker-test
+#
+# to make an image for testing cvs2svn and to run those tests using
+# the image.
+
+FROM debian:jessie AS run
+
+RUN apt-get update && \
+    apt-get install -y \
+        python \
+        python-bsddb3 \
+        subversion \
+        rcs \
+        cvs
+
+RUN mkdir /src
+WORKDIR /src
+COPY . .
+RUN ${PYTHON} ./setup.py install
+
+# The CVS repository can be mounted here:
+VOLUME ["/cvs"]
+
+# A volume for storing temporary files can be mounted here:
+VOLUME ["/tmp"]
+
+ENTRYPOINT ["cvs2svn"]
+
+FROM run AS test
+
+RUN ln -s /tmp cvs2svn-tmp
+
+ENTRYPOINT ["./run-tests.py"]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # The python interpreter to be used can be overridden here or via
 # something like "make ... PYTHON=/path/to/python2.5".  Please note
 # that this option only affects the "install" and "check" targets:
-PYTHON=python
+PYTHON := python
 
 all:
 	@echo "Supported make targets:"
@@ -31,12 +31,12 @@ dist:
 install:
 	@case "${DESTDIR}" in \
 	"") \
-	echo ${PYTHON} ./setup.py install ; \
-	${PYTHON} ./setup.py install ; \
-	;; \
+	    echo ${PYTHON} ./setup.py install ; \
+	    ${PYTHON} ./setup.py install ; \
+	    ;; \
 	*) \
-	echo ${PYTHON} ./setup.py install --root=${DESTDIR} ; \
-	${PYTHON} ./setup.py install --root=${DESTDIR} ; \
+	    echo ${PYTHON} ./setup.py install --root=${DESTDIR} ; \
+	    ${PYTHON} ./setup.py install --root=${DESTDIR} ; \
 	;; \
 	esac
 

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,24 @@ clean:
 		rm -f $$d/*.pyc $$d/*.pyo; \
 	done
 
+# Create a docker image, tagged `cvs2svn`, which is ready to run
+# `cvs2svn` (as its ENTRYPOINT). The image can be used as follows:
+#
+#     docker run -it --rm \
+#         --mount 'src=/path/to/my/cvs,dst=/cvs,readonly' \
+#         --mount 'type=volume,src=/tmp,dst=/tmp' \
+#         cvs2svn [OPTS] /cvs
+#
+# By default, temporary files are stored under `/tmp`, so this
+# invocation mounts your local `/tmp` directory there. You should
+# either make sure that your `/tmp` partition has enough free space,
+# or mount a different directory there.
+.PHONY: docker-image
+docker-image:
+	docker build --target=run -t cvs2svn .
+
+# Create a docker image, then use it to run the automated tests.
+.PHONY: docker-test
+docker-test:
+	docker build --target=test -t cvs2svn-test .
+	docker run -it --rm --mount 'type=tmpfs,dst=/tmp' cvs2svn-testing

--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ cvs2svn features or if you're debugging or patching cvs2svn, you might
 want to use the master version (which is usually quite stable). To do
 so, use Git to clone the repository, and run it straight from the
 working copy.
+
+This repository contains a `Dockerfile` that can be used to create a
+docker image in which cvs2svn can be run. (It has some dependencies
+that are no longer easily installable, so this is probably the easiest
+way to run cvs2svn.)

--- a/cvs2svn.md
+++ b/cvs2svn.md
@@ -53,6 +53,16 @@ cvs2svn requires the following:
   required. The CVS home page is http://ccvs.cvshome.org/. See the
   `--use-cvs` flag for more details.
 
+These dependencies are no longer so easy to find, so it might be
+convenient to use the `Dockerfile` in this repository to run
+`cvs2svn` inside a container. This can be done by running
+
+    make docker-image
+    docker run -it --rm \
+        --mount 'src=/path/to/my/cvs,dst=/cvs,readonly' \
+        --mount 'type=volume,src=/tmp,dst=/tmp' \
+        cvs2svn [OPTS] /cvs
+
 
 ## CVSNT repositories
 


### PR DESCRIPTION
This is probably the easiest way to run it nowadays, given that some of its dependencies are old and probably a little bit tricky to install.
