### PR TITLE
issue #18:RCSStream: Fix issue on inserting incomplete line on RCS diff

### DIFF
--- a/cvs2svn_lib/rcs_stream.py
+++ b/cvs2svn_lib/rcs_stream.py
@@ -137,6 +137,8 @@ def generate_edits_from_blocks(blocks):
 
   input_position = 0
   for (command, old_lines, new_lines) in blocks:
+    old_lines = msplit("".join(old_lines))
+    new_lines = msplit("".join(new_lines))
     if command == 'c':
       input_position += len(old_lines)
     elif command == 'r':
@@ -252,7 +254,13 @@ class RCSStream:
           yield ('c', copied_lines, copied_lines)
           del copied_lines
           input_pos = start
-        yield ('r', [], lines)
+        if lines[-1].endswith('\n') or input_pos == len(self._lines):
+          yield ('r', [], lines)
+        else:
+          copied_line = self._lines[input_pos]
+          yield ('r', [copied_line], lines + [copied_line])
+          del copied_line
+          input_pos = input_pos + 1
 
     # Pass along the part of the input that follows all of the delta
     # blocks:


### PR DESCRIPTION
The issue was that the reversed edits object were created against "logical lines" which can contains incomplete lines other than the last line created from latest revision with applying for each diff text through the revisions, while it always applied to "physical lines" that newly created by msplit function from its target file.

This commit changes it: make reversed edits object enable to apply to "physical lines".

* cvs2svn_lib/rcs_stream.py
  (generate_edits_from_blocks): Connect incomplete lines in old_lines
    and new_lines in command blocks.
  (RCSStream.generate_blocks): Add special case handling in 'a' command.