### PR TITLE
issues #20: Make run-test.py possible to run on environments nowadays.

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -46,6 +46,7 @@ import locale
 import textwrap
 import calendar
 import types
+import subprocess
 try:
   from hashlib import md5
 except ImportError:
@@ -53,9 +54,9 @@ except ImportError:
 from difflib import Differ
 
 # Make sure that a supported version of Python is being used:
-if not (0x02040000 <= sys.hexversion < 0x03000000):
+if not (0x02070000 <= sys.hexversion < 0x03000000):
   sys.stderr.write(
-      'error: Python 2, version 2.4 or higher required.\n'
+      'error: Python 2, version 2.7 or higher required.\n'
       )
   sys.exit(1)
 
@@ -4309,6 +4310,10 @@ if __name__ == '__main__':
   svntest.main.svnlook_binary     = svnlook_binary
   svntest.main.svnadmin_binary    = svnadmin_binary
   svntest.main.svnversion_binary  = svnversion_binary
+
+  # check version of svn_binary
+  svn_version = subprocess.check_output([svn_binary, '--version', '-q'])
+  svntest.main.SVN_VER_MINOR  = int(svn_version.split('.')[1])
 
   svntest.main.run_tests(test_list)
   # NOTREACHED

--- a/svntest/__init__.py
+++ b/svntest/__init__.py
@@ -23,11 +23,11 @@
 __all__ = [ ]
 
 import sys
-if sys.hexversion < 0x2050000:
-  sys.stderr.write('[SKIPPED] at least Python 2.5 is required\n')
+if sys.hexversion < 0x2070000:
+  sys.stderr.write('[SKIPPED] at least Python 2.7 is required\n')
 
   # note: exiting is a bit harsh for a library module, but we really do
-  # require Python 2.5. this package isn't going to work otherwise.
+  # require Python 2.7. this package isn't going to work otherwise.
 
   # we're skipping this test, not failing, so exit with 0
   sys.exit(0)
@@ -35,11 +35,8 @@ if sys.hexversion < 0x2050000:
 try:
   import sqlite3
 except ImportError:
-  try:
-    from pysqlite2 import dbapi2 as sqlite3
-  except ImportError:
-    sys.stderr.write('[SKIPPED] Python sqlite3 module required\n')
-    sys.exit(0)
+  sys.stderr.write('[SKIPPED] Python sqlite3 module required\n')
+  sys.exit(0)
 
 # don't export this name
 del sys
@@ -53,11 +50,11 @@ class Skip(Exception):
   pass
 
 # import in a specific order: things with the fewest circular imports first.
-import testcase
-import wc
-import verify
-import tree
-import sandbox
-import main
-import actions
-import factory
+from . import testcase
+from . import wc
+from . import verify
+from . import tree
+from . import sandbox
+from . import main
+from . import actions
+from . import factory

--- a/svntest/actions.py
+++ b/svntest/actions.py
@@ -35,10 +35,13 @@ else:
   from cStringIO import StringIO
 
 import svntest
-from svntest import main, verify, tree, wc
+from svntest import main, verify, tree, wc, sandbox
 from svntest import Failure
 
 logger = logging.getLogger()
+
+# (abbreviation)
+Item = svntest.wc.StateItem
 
 def _log_tree_state(msg, actual, subtree=""):
   if subtree:
@@ -61,7 +64,61 @@ def no_relocate_validation():
 def do_relocate_validation():
   os.environ['SVN_I_LOVE_CORRUPTED_WORKING_COPIES_SO_DISABLE_RELOCATE_VALIDATION'] = 'no'
 
-def setup_pristine_greek_repository():
+def _setup_pristine_repo(tree_state,
+                         repos_dir, dump_dir, repos_url,
+                         use_precooked=True):
+  # If there's no pristine repos, create one.
+  if not os.path.exists(repos_dir):
+    if use_precooked and main.options.fsfs_version is not None:
+      main.unpack_greek_repos(repos_dir)
+    else:
+      main.create_repos(repos_dir)
+
+      # if this is dav, gives us access rights to import the greek tree.
+      if main.is_ra_type_dav():
+        authz_file = os.path.join(main.work_dir, "authz")
+        main.file_write(authz_file, "[/]\n* = rw\n")
+
+      # dump the greek tree to disk.
+      tree_state.write_to_disk(dump_dir)
+
+      # import the greek tree, using l:foo/p:bar
+      ### todo: svn should not be prompting for auth info when using
+      ### repositories with no auth/auth requirements
+      _, output, _ = main.run_svn(None, 'import', '-m',
+                                  'Log message for revision 1.',
+                                  dump_dir, repos_url)
+
+      # verify the printed output of 'svn import'.
+      lastline = output.pop().strip()
+      match = re.search("(Committed|Imported) revision [0-9]+.", lastline)
+      if not match:
+        logger.error("import did not succeed, while creating greek repos.")
+        logger.error("The final line from 'svn import' was:")
+        logger.error(lastline)
+        sys.exit(1)
+      output_tree = wc.State.from_commit(output)
+
+      expected_output_tree = tree_state.copy(dump_dir)
+      expected_output_tree.tweak(verb='Adding',
+                                 contents=None)
+
+      try:
+        expected_output_tree.compare_and_display('output', output_tree)
+      except tree.SVNTreeUnequal:
+        verify.display_trees("ERROR:  output of import command is unexpected.",
+                             "OUTPUT TREE",
+                             expected_output_tree.old_tree(),
+                             output_tree.old_tree())
+        sys.exit(1)
+
+    # Finally, disallow any changes to the "pristine" repos.
+    error_msg = "Don't modify the pristine repository"
+    create_failing_hook(repos_dir, 'start-commit', error_msg)
+    create_failing_hook(repos_dir, 'pre-lock', error_msg)
+    create_failing_hook(repos_dir, 'pre-revprop-change', error_msg)
+
+def setup_pristine_repositories():
   """Create the pristine repository and 'svn import' the greek tree"""
 
   # these directories don't exist out of the box, so we may have to create them
@@ -71,65 +128,27 @@ def setup_pristine_greek_repository():
   if not os.path.exists(main.general_repo_dir):
     os.makedirs(main.general_repo_dir) # this also creates all the intermediate dirs
 
-  # If there's no pristine repos, create one.
-  if not os.path.exists(main.pristine_greek_repos_dir):
-    main.create_repos(main.pristine_greek_repos_dir)
+  if not os.path.exists(main.other_dav_root_dir):
+    os.makedirs(main.other_dav_root_dir)
+  if not os.path.exists(main.non_dav_root_dir):
+    os.makedirs(main.non_dav_root_dir)
 
-    # if this is dav, gives us access rights to import the greek tree.
-    if main.is_ra_type_dav():
-      authz_file = os.path.join(main.work_dir, "authz")
-      main.file_write(authz_file, "[/]\n* = rw\n")
+  _setup_pristine_repo(main.greek_state,
+                       main.pristine_greek_repos_dir,
+                       main.greek_dump_dir,
+                       main.pristine_greek_repos_url)
 
-    # dump the greek tree to disk.
-    main.greek_state.write_to_disk(main.greek_dump_dir)
-
-    # import the greek tree, using l:foo/p:bar
-    ### todo: svn should not be prompting for auth info when using
-    ### repositories with no auth/auth requirements
-    exit_code, output, errput = main.run_svn(None, 'import', '-m',
-                                             'Log message for revision 1.',
-                                             main.greek_dump_dir,
-                                             main.pristine_greek_repos_url)
-
-    # check for any errors from the import
-    if len(errput):
-      display_lines("Errors during initial 'svn import':",
-                    'STDERR', None, errput)
-      sys.exit(1)
-
-    # verify the printed output of 'svn import'.
-    lastline = output.pop().strip()
-    match = re.search("(Committed|Imported) revision [0-9]+.", lastline)
-    if not match:
-      logger.error("import did not succeed, while creating greek repos.")
-      logger.error("The final line from 'svn import' was:")
-      logger.error(lastline)
-      sys.exit(1)
-    output_tree = wc.State.from_commit(output)
-
-    expected_output_tree = main.greek_state.copy(main.greek_dump_dir)
-    expected_output_tree.tweak(verb='Adding',
-                               contents=None)
-
-    try:
-      expected_output_tree.compare_and_display('output', output_tree)
-    except tree.SVNTreeUnequal:
-      verify.display_trees("ERROR:  output of import command is unexpected.",
-                           "OUTPUT TREE",
-                           expected_output_tree.old_tree(),
-                           output_tree.old_tree())
-      sys.exit(1)
-
-    # Finally, disallow any changes to the "pristine" repos.
-    error_msg = "Don't modify the pristine repository"
-    create_failing_hook(main.pristine_greek_repos_dir, 'start-commit', error_msg)
-    create_failing_hook(main.pristine_greek_repos_dir, 'pre-lock', error_msg)
-    create_failing_hook(main.pristine_greek_repos_dir, 'pre-revprop-change', error_msg)
+  # NOTE: We don't use precooked trojan repositories.
+  _setup_pristine_repo(main.trojan_state,
+                       main.pristine_trojan_repos_dir,
+                       main.trojan_dump_dir,
+                       main.pristine_trojan_repos_url,
+                       use_precooked=False)
 
 
 ######################################################################
 
-def guarantee_empty_repository(path):
+def guarantee_empty_repository(path, minor_version):
   """Guarantee that a local svn repository exists at PATH, containing
   nothing."""
 
@@ -139,33 +158,47 @@ def guarantee_empty_repository(path):
 
   # create an empty repository at PATH.
   main.safe_rmtree(path)
-  main.create_repos(path)
+  main.create_repos(path, minor_version)
 
 # Used by every test, so that they can run independently of  one
 # another. Every time this routine is called, it recursively copies
 # the `pristine repos' to a new location.
-# Note: make sure setup_pristine_greek_repository was called once before
-# using this function.
-def guarantee_greek_repository(path, minor_version):
-  """Guarantee that a local svn repository exists at PATH, containing
-  nothing but the greek-tree at revision 1."""
-
-  if path == main.pristine_greek_repos_dir:
+# Note: make sure setup_pristine_repositories was called once before
+# using these functions.
+def _guarantee_repos(path, repos_dir, minor_version, use_precooked=True):
+  if path == repos_dir:
     logger.error("attempt to overwrite the pristine repos!  Aborting.")
     sys.exit(1)
 
   # copy the pristine repository to PATH.
   main.safe_rmtree(path)
-  if main.copy_repos(main.pristine_greek_repos_dir, path, 1, 1, minor_version):
+  if (use_precooked and main.options.fsfs_version is not None):
+    failed = main.unpack_greek_repos(path)
+  else:
+    failed = main.copy_repos(repos_dir, path, 1, 1, minor_version)
+  if failed:
     logger.error("copying repository failed.")
     sys.exit(1)
 
   # make the repos world-writeable, for mod_dav_svn's sake.
-  main.chmod_tree(path, 0666, 0666)
+  main.chmod_tree(path, main.S_ALL_RW, main.S_ALL_RW)
 
+  # give the repository a unique UUID
+  run_and_verify_svnadmin([], [], 'setuuid', path)
 
-def run_and_verify_atomic_ra_revprop_change(message,
-                                            expected_stdout,
+def guarantee_greek_repository(path, minor_version):
+  """Guarantee that a local svn repository exists at PATH, containing
+  nothing but the greek-tree at revision 1."""
+
+  _guarantee_repos(path, main.pristine_greek_repos_dir, minor_version)
+
+def guarantee_trojan_repository(path, minor_version):
+  """Guarantee that a local svn repository exists at PATH, containing
+  nothing but the trojan-tree at revision 1."""
+
+  _guarantee_repos(path, main.pristine_trojan_repos_dir, minor_version, False)
+
+def run_and_verify_atomic_ra_revprop_change(expected_stdout,
                                             expected_stderr,
                                             expected_exit,
                                             url, revision, propname,
@@ -195,11 +228,11 @@ def run_and_verify_atomic_ra_revprop_change(message,
                                                           want_error)
   verify.verify_outputs("Unexpected output", out, err,
                         expected_stdout, expected_stderr)
-  verify.verify_exit_code(message, exit_code, expected_exit)
+  verify.verify_exit_code("Unexpected return code", exit_code, expected_exit)
   return exit_code, out, err
 
 
-def run_and_verify_svnlook(message, expected_stdout,
+def run_and_verify_svnlook(expected_stdout,
                            expected_stderr, *varargs):
   """Like run_and_verify_svnlook2, but the expected exit code is
   assumed to be 0 if no output is expected on stderr, and 1 otherwise."""
@@ -207,21 +240,21 @@ def run_and_verify_svnlook(message, expected_stdout,
   expected_exit = 0
   if expected_stderr is not None and expected_stderr != []:
     expected_exit = 1
-  return run_and_verify_svnlook2(message, expected_stdout, expected_stderr,
+  return run_and_verify_svnlook2(expected_stdout, expected_stderr,
                                  expected_exit, *varargs)
 
-def run_and_verify_svnlook2(message, expected_stdout, expected_stderr,
+def run_and_verify_svnlook2(expected_stdout, expected_stderr,
                             expected_exit, *varargs):
   """Run svnlook command and check its output and exit code."""
 
   exit_code, out, err = main.run_svnlook(*varargs)
   verify.verify_outputs("Unexpected output", out, err,
                         expected_stdout, expected_stderr)
-  verify.verify_exit_code(message, exit_code, expected_exit)
+  verify.verify_exit_code("Unexpected return code", exit_code, expected_exit)
   return exit_code, out, err
 
 
-def run_and_verify_svnadmin(message, expected_stdout,
+def run_and_verify_svnadmin(expected_stdout,
                             expected_stderr, *varargs):
   """Like run_and_verify_svnadmin2, but the expected exit code is
   assumed to be 0 if no output is expected on stderr, and 1 otherwise."""
@@ -229,21 +262,43 @@ def run_and_verify_svnadmin(message, expected_stdout,
   expected_exit = 0
   if expected_stderr is not None and expected_stderr != []:
     expected_exit = 1
-  return run_and_verify_svnadmin2(message, expected_stdout, expected_stderr,
+  return run_and_verify_svnadmin2(expected_stdout, expected_stderr,
                                   expected_exit, *varargs)
 
-def run_and_verify_svnadmin2(message, expected_stdout, expected_stderr,
+def run_and_verify_svnadmin2(expected_stdout, expected_stderr,
                              expected_exit, *varargs):
   """Run svnadmin command and check its output and exit code."""
 
   exit_code, out, err = main.run_svnadmin(*varargs)
   verify.verify_outputs("Unexpected output", out, err,
                         expected_stdout, expected_stderr)
-  verify.verify_exit_code(message, exit_code, expected_exit)
+  verify.verify_exit_code("Unexpected return code", exit_code, expected_exit)
   return exit_code, out, err
 
 
-def run_and_verify_svnversion(message, wc_dir, trail_url,
+def run_and_verify_svnfsfs(expected_stdout,
+                           expected_stderr, *varargs):
+  """Like run_and_verify_svnfsfs2, but the expected exit code is
+  assumed to be 0 if no output is expected on stderr, and 1 otherwise."""
+
+  expected_exit = 0
+  if expected_stderr is not None and expected_stderr != []:
+    expected_exit = 1
+  return run_and_verify_svnfsfs2(expected_stdout, expected_stderr,
+                                 expected_exit, *varargs)
+
+def run_and_verify_svnfsfs2(expected_stdout, expected_stderr,
+                            expected_exit, *varargs):
+  """Run svnfsfs command and check its output and exit code."""
+
+  exit_code, out, err = main.run_svnfsfs(*varargs)
+  verify.verify_outputs("Unexpected output", out, err,
+                        expected_stdout, expected_stderr)
+  verify.verify_exit_code("Unexpected return code", exit_code, expected_exit)
+  return exit_code, out, err
+
+
+def run_and_verify_svnversion(wc_dir, trail_url,
                               expected_stdout, expected_stderr, *varargs):
   """like run_and_verify_svnversion2, but the expected exit code is
   assumed to be 0 if no output is expected on stderr, and 1 otherwise."""
@@ -251,11 +306,11 @@ def run_and_verify_svnversion(message, wc_dir, trail_url,
   expected_exit = 0
   if expected_stderr is not None and expected_stderr != []:
     expected_exit = 1
-  return run_and_verify_svnversion2(message, wc_dir, trail_url,
+  return run_and_verify_svnversion2(wc_dir, trail_url,
                                     expected_stdout, expected_stderr,
                                     expected_exit, *varargs)
 
-def run_and_verify_svnversion2(message, wc_dir, trail_url,
+def run_and_verify_svnversion2(wc_dir, trail_url,
                                expected_stdout, expected_stderr,
                                expected_exit, *varargs):
   """Run svnversion command and check its output and exit code."""
@@ -267,10 +322,10 @@ def run_and_verify_svnversion2(message, wc_dir, trail_url,
 
   verify.verify_outputs("Unexpected output", out, err,
                         expected_stdout, expected_stderr)
-  verify.verify_exit_code(message, exit_code, expected_exit)
+  verify.verify_exit_code("Unexpected return code", exit_code, expected_exit)
   return exit_code, out, err
 
-def run_and_verify_svn(message, expected_stdout, expected_stderr, *varargs):
+def run_and_verify_svn(expected_stdout, expected_stderr, *varargs):
   """like run_and_verify_svn2, but the expected exit code is assumed to
   be 0 if no output is expected on stderr, and 1 otherwise."""
 
@@ -281,10 +336,10 @@ def run_and_verify_svn(message, expected_stdout, expected_stderr, *varargs):
         expected_exit = 1
     elif expected_stderr != []:
       expected_exit = 1
-  return run_and_verify_svn2(message, expected_stdout, expected_stderr,
+  return run_and_verify_svn2(expected_stdout, expected_stderr,
                              expected_exit, *varargs)
 
-def run_and_verify_svn2(message, expected_stdout, expected_stderr,
+def run_and_verify_svn2(expected_stdout, expected_stderr,
                         expected_exit, *varargs):
   """Invoke main.run_svn() with *VARARGS. Return exit code as int; stdout,
   stderr as lists of lines (including line terminators).  For both
@@ -299,7 +354,7 @@ def run_and_verify_svn2(message, expected_stdout, expected_stderr,
      - If it is already an instance of ExpectedOutput
        (e.g. UnorderedOutput), leave it alone.
 
-  ...and invoke compare_and_display_lines() on MESSAGE, a label based
+  ...and invoke compare_and_display_lines() on a label based
   on the name of the stream being compared (e.g. STDOUT), the
   ExpectedOutput instance, and the actual output.
 
@@ -321,38 +376,36 @@ def run_and_verify_svn2(message, expected_stdout, expected_stderr,
     want_err = True
 
   exit_code, out, err = main.run_svn(want_err, *varargs)
-  verify.verify_outputs(message, out, err, expected_stdout, expected_stderr)
-  verify.verify_exit_code(message, exit_code, expected_exit)
+  verify.verify_outputs("Unexpected output", out, err,
+                        expected_stdout, expected_stderr)
+  verify.verify_exit_code("Unexpected return code", exit_code, expected_exit)
   return exit_code, out, err
 
 def run_and_verify_load(repo_dir, dump_file_content,
-                        bypass_prop_validation = False):
+                        bypass_prop_validation = False,
+                        normalize_props = False):
   "Runs 'svnadmin load' and reports any errors."
   if not isinstance(dump_file_content, list):
     raise TypeError("dump_file_content argument should have list type")
   expected_stderr = []
+  args = ()
   if bypass_prop_validation:
-    exit_code, output, errput = main.run_command_stdin(
-      main.svnadmin_binary, expected_stderr, 0, 1, dump_file_content,
-      'load', '--force-uuid', '--quiet', '--bypass-prop-validation', repo_dir)
-  else:
-    exit_code, output, errput = main.run_command_stdin(
-      main.svnadmin_binary, expected_stderr, 0, 1, dump_file_content,
-      'load', '--force-uuid', '--quiet', repo_dir)
-
-  verify.verify_outputs("Unexpected stderr output", None, errput,
-                        None, expected_stderr)
+    args += ('--bypass-prop-validation',)
+  if normalize_props:
+    args += ('--normalize-props',)
+  main.run_command_stdin(
+    main.svnadmin_binary, expected_stderr, 0, True, dump_file_content,
+    'load', '--force-uuid', '--quiet', repo_dir, *args)
 
 
 def run_and_verify_dump(repo_dir, deltas=False):
   "Runs 'svnadmin dump' and reports any errors, returning the dump content."
+  args = ()
   if deltas:
-    exit_code, output, errput = main.run_svnadmin('dump', '--deltas',
-                                                  repo_dir)
-  else:
-    exit_code, output, errput = main.run_svnadmin('dump', repo_dir)
-  verify.verify_outputs("Missing expected output(s)", output, errput,
-                        verify.AnyOutput, verify.AnyOutput)
+    args += ('--deltas',)
+  exit_code, output, errput = run_and_verify_svnadmin(
+                                verify.AnyOutput, [],
+                                'dump', '--quiet', repo_dir, *args)
   return output
 
 
@@ -365,8 +418,10 @@ def run_and_verify_svnrdump(dumpfile_content, expected_stdout,
   # Since main.run_svnrdump() uses binary mode, normalize the stderr
   # line endings on Windows ourselves.
   if sys.platform == 'win32':
-    err = map(lambda x : x.replace('\r\n', '\n'), err)
+    err = [x.replace('\r\n', '\n') for x in err]
 
+  # Ignore "consider upgrade" warnings to allow regression tests to pass
+  # when run against a 1.6 mod_dav_svn.
   for index, line in enumerate(err[:]):
     if re.search("warning: W200007", line):
       del err[index]
@@ -377,32 +432,83 @@ def run_and_verify_svnrdump(dumpfile_content, expected_stdout,
   return output
 
 
-def run_and_verify_svnmucc(message, expected_stdout, expected_stderr,
+def run_and_verify_svnmover(expected_stdout, expected_stderr,
+                            *varargs):
+  """Run svnmover command and check its output"""
+
+  expected_exit = 0
+  if expected_stderr is not None and expected_stderr != []:
+    expected_exit = 1
+  return run_and_verify_svnmover2(expected_stdout, expected_stderr,
+                                  expected_exit, *varargs)
+
+def run_and_verify_svnmover2(expected_stdout, expected_stderr,
+                             expected_exit, *varargs):
+  """Run svnmover command and check its output and exit code."""
+
+  exit_code, out, err = main.run_svnmover(*varargs)
+  verify.verify_outputs("Unexpected output", out, err,
+                        expected_stdout, expected_stderr)
+  verify.verify_exit_code("Unexpected return code", exit_code, expected_exit)
+  return exit_code, out, err
+
+
+def run_and_verify_svnmucc(expected_stdout, expected_stderr,
                            *varargs):
   """Run svnmucc command and check its output"""
 
   expected_exit = 0
   if expected_stderr is not None and expected_stderr != []:
     expected_exit = 1
-  return run_and_verify_svnmucc2(message, expected_stdout, expected_stderr,
+  return run_and_verify_svnmucc2(expected_stdout, expected_stderr,
                                  expected_exit, *varargs)
 
-def run_and_verify_svnmucc2(message, expected_stdout, expected_stderr,
+def run_and_verify_svnmucc2(expected_stdout, expected_stderr,
                             expected_exit, *varargs):
   """Run svnmucc command and check its output and exit code."""
 
   exit_code, out, err = main.run_svnmucc(*varargs)
   verify.verify_outputs("Unexpected output", out, err,
                         expected_stdout, expected_stderr)
-  verify.verify_exit_code(message, exit_code, expected_exit)
+  verify.verify_exit_code("Unexpected return code", exit_code, expected_exit)
+  return exit_code, out, err
+
+
+def run_and_verify_svnsync(expected_stdout, expected_stderr,
+                           *varargs):
+  """Run svnsync command and check its output"""
+
+  expected_exit = 0
+  if expected_stderr is not None and expected_stderr != []:
+    expected_exit = 1
+  return run_and_verify_svnsync2(expected_stdout, expected_stderr,
+                                 expected_exit, *varargs)
+
+def run_and_verify_svnsync2(expected_stdout, expected_stderr,
+                            expected_exit, *varargs):
+  """Run svnsync command and check its output and exit code."""
+
+  exit_code, out, err = main.run_svnsync(*varargs)
+
+  # Ignore "consider upgrade" warnings to allow regression tests to pass
+  # when run against a 1.6 mod_dav_svn.
+  for index, line in enumerate(err[:]):
+    if re.search("warning: W200007", line):
+      del err[index]
+
+  verify.verify_outputs("Unexpected output", out, err,
+                        expected_stdout, expected_stderr)
+  verify.verify_exit_code("Unexpected return code", exit_code, expected_exit)
   return exit_code, out, err
 
 
 def load_repo(sbox, dumpfile_path = None, dump_str = None,
-              bypass_prop_validation = False):
+              bypass_prop_validation = False, create_wc=True,
+              normalize_props = False):
   "Loads the dumpfile into sbox"
   if not dump_str:
-    dump_str = open(dumpfile_path, "rb").read()
+    with open(dumpfile_path, "rb") as fp:
+      dump_str = fp.read()
 
   # Create a virgin repos and working copy
   main.safe_rmtree(sbox.repo_dir, 1)
@@ -411,8 +517,9 @@ def load_repo(sbox, dumpfile_path = None, dump_str = None,
 
   # Load the mergetracking dumpfile into the repos, and check it out the repo
   run_and_verify_load(sbox.repo_dir, dump_str.splitlines(True),
-                      bypass_prop_validation)
-  run_and_verify_svn(None, None, [], "co", sbox.repo_url, sbox.wc_dir)
+                      bypass_prop_validation, normalize_props)
+  if create_wc:
+    run_and_verify_svn(None, [], "co", sbox.repo_url, sbox.wc_dir)
 
   return dump_str
 
@@ -424,6 +531,22 @@ def expected_noop_update_output(rev):
                                      % (rev),
                                      "no-op update")
 
+def run_and_verify_svnauthz(expected_stdout, expected_stderr,
+                            expected_exit, compat_mode, *varargs):
+  """Run svnauthz command and check its output and exit code.
+     If COMPAT_MODE is True then run the command in pre-1.8
+     compatibility mode"""
+
+  if compat_mode:
+    exit_code, out, err = main.run_svnauthz_validate(*varargs)
+  else:
+    exit_code, out, err = main.run_svnauthz(*varargs)
+
+  verify.verify_outputs("Unexpected output", out, err,
+                        expected_stdout, expected_stderr)
+  verify.verify_exit_code("Unexpected return code", exit_code, expected_exit)
+  return exit_code, out, err
+
 ######################################################################
 # Subversion Actions
 #
@@ -433,13 +556,9 @@ def expected_noop_update_output(rev):
 #
 
 
-def run_and_verify_checkout2(do_remove,
-                             URL, wc_dir_name, output_tree, disk_tree,
-                             singleton_handler_a = None,
-                             a_baton = None,
-                             singleton_handler_b = None,
-                             b_baton = None,
-                             *args):
+def run_and_verify_checkout(URL, wc_dir_name, output_tree, disk_tree,
+                            expected_stderr=[],
+                            *args, **kw):
   """Checkout the URL into a new directory WC_DIR_NAME. *ARGS are any
   extra optional args to the checkout subcommand.
 
@@ -455,20 +574,13 @@ def run_and_verify_checkout2(do_remove,
 
   if isinstance(output_tree, wc.State):
     output_tree = output_tree.old_tree()
-  if isinstance(disk_tree, wc.State):
-    disk_tree = disk_tree.old_tree()
-
-  # Remove dir if it's already there, unless this is a forced checkout.
-  # In that case assume we want to test a forced checkout's toleration
-  # of obstructing paths.
-  if do_remove:
-    main.safe_rmtree(wc_dir_name)
 
   # Checkout and make a tree of the output, using l:foo/p:bar
   ### todo: svn should not be prompting for auth info when using
   ### repositories with no auth/auth requirements
-  exit_code, output, errput = main.run_svn(None, 'co',
-                                           URL, wc_dir_name, *args)
+  exit_code, output, errput = run_and_verify_svn(None, expected_stderr,
+                                                 'co', URL, wc_dir_name,
+                                                 *args)
   actual = tree.build_tree_from_checkout(output)
 
   # Verify actual output against expected output.
@@ -478,47 +590,27 @@ def run_and_verify_checkout2(do_remove,
     _log_tree_state("ACTUAL OUTPUT TREE:", actual, wc_dir_name)
     raise
 
-  # Create a tree by scanning the working copy
-  actual = tree.build_tree_from_wc(wc_dir_name)
-
-  # Verify expected disk against actual disk.
-  try:
-    tree.compare_trees("disk", actual, disk_tree,
-                       singleton_handler_a, a_baton,
-                       singleton_handler_b, b_baton)
-  except tree.SVNTreeUnequal:
-    _log_tree_state("ACTUAL DISK TREE:", actual, wc_dir_name)
-    raise
-
-def run_and_verify_checkout(URL, wc_dir_name, output_tree, disk_tree,
-                            singleton_handler_a = None,
-                            a_baton = None,
-                            singleton_handler_b = None,
-                            b_baton = None,
-                            *args):
-  """Same as run_and_verify_checkout2(), but without the DO_REMOVE arg.
-  WC_DIR_NAME is deleted if present unless the '--force' option is passed
-  in *ARGS."""
-
-
-  # Remove dir if it's already there, unless this is a forced checkout.
-  # In that case assume we want to test a forced checkout's toleration
-  # of obstructing paths.
-  return run_and_verify_checkout2(('--force' not in args),
-                                  URL, wc_dir_name, output_tree, disk_tree,
-                                  singleton_handler_a,
-                                  a_baton,
-                                  singleton_handler_b,
-                                  b_baton,
-                                  *args)
-
+  if disk_tree:
+    verify_disk(wc_dir_name, disk_tree, False, **kw)
 
 def run_and_verify_export(URL, export_dir_name, output_tree, disk_tree,
                           *args):
+  """Same as run_and_verify_export2 but with KEEP_EOL_STYLE set to False."""
+
+  run_and_verify_export2(URL, export_dir_name, output_tree, disk_tree,
+                         False, *args)
+
+def run_and_verify_export2(URL, export_dir_name, output_tree, disk_tree,
+                           keep_eol_style=False, *args):
   """Export the URL into a new directory WC_DIR_NAME.
 
   The subcommand output will be verified against OUTPUT_TREE,
   and the exported copy itself will be verified against DISK_TREE.
+
+  If KEEP_EOL_STYLE is set, don't let Python normalize the EOL when
+  reading working copy contents as text files.  It has no effect on
+  binary files.
+
   Return if successful, raise on failure.
   """
   assert isinstance(output_tree, wc.State)
@@ -544,7 +636,8 @@ def run_and_verify_export(URL, export_dir_name, output_tree, disk_tree,
   # Create a tree by scanning the working copy.  Don't ignore
   # the .svn directories so that we generate an error if they
   # happen to show up.
-  actual = tree.build_tree_from_wc(export_dir_name, ignore_svn=False)
+  actual = tree.build_tree_from_wc(export_dir_name, ignore_svn=False,
+                                   keep_eol_style=keep_eol_style)
 
   # Verify expected disk against actual disk.
   try:
@@ -557,8 +650,13 @@ def run_and_verify_export(URL, export_dir_name, output_tree, disk_tree,
 # run_and_verify_log_xml
 
 class LogEntry:
-  def __init__(self, revision, changed_paths=None, revprops=None):
+  def __init__(self, revision, attributes=None,
+               changed_paths=None, revprops=None):
     self.revision = revision
+    if attributes == None:
+      self.attributes = {}
+    else:
+      self.attributes = attributes
     if changed_paths == None:
       self.changed_paths = {}
     else:
@@ -567,6 +665,15 @@ class LogEntry:
       self.revprops = {}
     else:
       self.revprops = revprops
+
+  def assert_log_attrs(self, attributes):
+    """Assert that attributes is the same as this entry's attributes
+    Raises svntest.Failure if not.
+    """
+    if self.attributes != attributes:
+      raise Failure('\n' + '\n'.join(difflib.ndiff(
+            pprint.pformat(attributes).splitlines(),
+            pprint.pformat(self.attributes).splitlines())))
 
   def assert_changed_paths(self, changed_paths):
     """Assert that changed_paths is the same as this entry's changed_paths
@@ -597,7 +704,7 @@ class LogParser:
       for i in data:
         self.parser.Parse(i)
       self.parser.Parse('', True)
-    except xml.parsers.expat.ExpatError, e:
+    except xml.parsers.expat.ExpatError as e:
       raise verify.SVNUnexpectedStdout('%s\n%s\n' % (e, ''.join(data),))
     return self.entries
 
@@ -645,7 +752,7 @@ class LogParser:
 
   # element handlers
   def logentry_start(self, attrs):
-    self.entries.append(LogEntry(int(attrs['revision'])))
+    self.entries.append(LogEntry(int(attrs['revision']), attrs))
   def author_end(self):
     self.svn_prop('author')
   def msg_end(self):
@@ -665,15 +772,18 @@ class LogParser:
     self.entries[-1].changed_paths[self.use_cdata()] = [{'kind': self.kind,
                                                          'action': self.action}]
 
-def run_and_verify_log_xml(message=None, expected_paths=None,
-                           expected_revprops=None, expected_stdout=None,
-                           expected_stderr=None, args=[]):
+def run_and_verify_log_xml(expected_log_attrs=None,
+                           expected_paths=None, expected_revprops=None,
+                           expected_stdout=None, expected_stderr=None,
+                           args=[]):
   """Call run_and_verify_svn with log --xml and args (optional) as command
-  arguments, and pass along message, expected_stdout, and expected_stderr.
-
-  If message is None, pass the svn log command as message.
+  arguments, and pass along expected_stdout, and expected_stderr.
 
   expected_paths checking is not yet implemented.
+
+  expected_log_attrs is an optional list of dicts, compared to each revisions's
+  logentry attributes.  The list must be in the same order the log entries
+  come in.
 
   expected_revprops is an optional list of dicts, compared to each
   revision's revprops.  The list must be in the same order the log entries
@@ -683,8 +793,7 @@ def run_and_verify_log_xml(message=None, expected_paths=None,
   expected_paths and expected_revprops are ignored if expected_stdout or
   expected_stderr is specified.
   """
-  if message == None:
-    message = ' '.join(args)
+  message = ' '.join(args)
 
   # We'll parse the output unless the caller specifies expected_stderr or
   # expected_stdout for run_and_verify_svn.
@@ -701,7 +810,7 @@ def run_and_verify_log_xml(message=None, expected_paths=None,
     log_args.append('-v')
 
   (exit_code, stdout, stderr) = run_and_verify_svn(
-    message, expected_stdout, expected_stderr,
+    expected_stdout, expected_stderr,
     'log', '--xml', *log_args)
   if not parse:
     return
@@ -713,6 +822,8 @@ def run_and_verify_log_xml(message=None, expected_paths=None,
       entry.assert_revprops(expected_revprops[index])
     if expected_paths != None:
       entry.assert_changed_paths(expected_paths[index])
+    if expected_log_attrs != None:
+      entry.assert_log_attrs(expected_log_attrs[index])
 
 
 def verify_update(actual_output,
@@ -724,11 +835,9 @@ def verify_update(actual_output,
                   elision_output_tree,
                   disk_tree,
                   status_tree,
-                  singleton_handler_a=None,
-                  a_baton=None,
-                  singleton_handler_b=None,
-                  b_baton=None,
-                  check_props=False):
+                  check_props=False,
+                  keep_eol_style=False,
+                  extra_files=None):
   """Verify update of WC_DIR_NAME.
 
   The subcommand output (found in ACTUAL_OUTPUT, ACTUAL_MERGEINFO_OUTPUT,
@@ -739,6 +848,10 @@ def verify_update(actual_output,
   provided), and the working copy's 'svn status' output will be verified
   against STATUS_TREE (if provided).  (This is a good way to check that
   revision numbers were bumped.)
+
+  If KEEP_EOL_STYLE is set, don't let Python normalize the EOL when
+  reading working copy contents as text files.  It has no effect on
+  binary files.
 
   Return if successful, raise on failure.
 
@@ -759,10 +872,6 @@ def verify_update(actual_output,
     mergeinfo_output_tree = mergeinfo_output_tree.old_tree()
   if isinstance(elision_output_tree, wc.State):
     elision_output_tree = elision_output_tree.old_tree()
-  if isinstance(disk_tree, wc.State):
-    disk_tree = disk_tree.old_tree()
-  if isinstance(status_tree, wc.State):
-    status_tree = status_tree.old_tree()
 
   # Verify actual output against expected output.
   if output_tree:
@@ -794,39 +903,74 @@ def verify_update(actual_output,
 
   # Create a tree by scanning the working copy, and verify it
   if disk_tree:
-    actual_disk = tree.build_tree_from_wc(wc_dir_name, check_props)
-    try:
-      tree.compare_trees("disk", actual_disk, disk_tree,
-                         singleton_handler_a, a_baton,
-                         singleton_handler_b, b_baton)
-    except tree.SVNTreeUnequal:
-      _log_tree_state("EXPECTED DISK TREE:", disk_tree)
-      _log_tree_state("ACTUAL DISK TREE:", actual_disk)
-      raise
+    verify_disk(wc_dir_name, disk_tree, check_props,
+                extra_files, keep_eol_style)
 
   # Verify via 'status' command too, if possible.
   if status_tree:
     run_and_verify_status(wc_dir_name, status_tree)
 
 
-def verify_disk(wc_dir_name, disk_tree, check_props=False):
+def verify_disk(wc_dir_name, disk_tree, check_props=False,
+                extra_files=None, keep_eol_style=False):
   """Verify WC_DIR_NAME against DISK_TREE.  If CHECK_PROPS is set,
-  the comparison will examin props.  Returns if successful, raises on
-  failure."""
-  verify_update(None, None, None, wc_dir_name, None, None, None, disk_tree,
-                None, check_props=check_props)
+  the comparison will examin props.
 
+  If KEEP_EOL_STYLE is set, don't let Python normalize the EOL when
+  reading working copy contents as text files.  It has no effect on
+  binary files.
+
+  Returns if successful, raises on failure."""
+
+  singleton_handler_a = None
+  a_baton = None,
+  singleton_handler_b = None
+  b_baton = None
+  done_a = None
+
+  if extra_files:
+    singleton_handler_a = svntest.tree.detect_conflict_files
+    done_a = svntest.tree.detect_conflict_files_done
+    a_baton = extra_files
+
+  if isinstance(disk_tree, wc.State):
+    disk_tree = disk_tree.old_tree()
+
+  actual_disk = tree.build_tree_from_wc(wc_dir_name, check_props,
+                                        keep_eol_style=keep_eol_style)
+  try:
+    tree.compare_trees("disk", actual_disk, disk_tree,
+                       singleton_handler_a, a_baton,
+                       singleton_handler_b, b_baton)
+  except tree.SVNTreeUnequal:
+    _log_tree_state("EXPECTED DISK TREE:", disk_tree)
+    _log_tree_state("ACTUAL DISK TREE:", actual_disk)
+    raise
+
+  if done_a:
+    done_a(a_baton)
 
 
 def run_and_verify_update(wc_dir_name,
                           output_tree, disk_tree, status_tree,
-                          error_re_string = None,
-                          singleton_handler_a = None,
-                          a_baton = None,
-                          singleton_handler_b = None,
-                          b_baton = None,
+                          expected_stderr=[],
                           check_props = False,
-                          *args):
+                          *args, **kw):
+  """Same as run_and_verify_update2 but with keep_eol_style set to False."""
+  run_and_verify_update2(wc_dir_name,
+                         output_tree, disk_tree, status_tree,
+                         expected_stderr,
+                         check_props,
+                         False,
+                         *args, **kw)
+
+
+def run_and_verify_update2(wc_dir_name,
+                           output_tree, disk_tree, status_tree,
+                           expected_stderr=[],
+                           check_props = False,
+                           keep_eol_style = False,
+                           *args, **kw):
 
   """Update WC_DIR_NAME.  *ARGS are any extra optional args to the
   update subcommand.  NOTE: If *ARGS is specified at all, explicit
@@ -838,44 +982,30 @@ def run_and_verify_update(wc_dir_name,
   If ERROR_RE_STRING, the update must exit with error, and the error
   message must match regular expression ERROR_RE_STRING.
 
-  Else if ERROR_RE_STRING is None, then:
-
   If OUTPUT_TREE is not None, the subcommand output will be verified
   against OUTPUT_TREE.  If DISK_TREE is not None, the working copy
   itself will be verified against DISK_TREE.  If STATUS_TREE is not
   None, the 'svn status' output will be verified against STATUS_TREE.
   (This is a good way to check that revision numbers were bumped.)
 
-  For the DISK_TREE verification, SINGLETON_HANDLER_A and
-  SINGLETON_HANDLER_B will be passed to tree.compare_trees -- see that
-  function's doc string for more details.
-
   If CHECK_PROPS is set, then disk comparison will examine props.
+
+  If KEEP_EOL_STYLE is set, don't let Python normalize the EOL when
+  reading working copy contents as text files.  It has no effect on
+  binary files.
 
   Return if successful, raise on failure."""
 
   # Update and make a tree of the output.
-  if len(args):
-    exit_code, output, errput = main.run_svn(error_re_string, 'up', *args)
-  else:
-    exit_code, output, errput = main.run_svn(error_re_string,
-                                             'up', wc_dir_name,
-                                             *args)
+  if len(args) == 0:
+    args = (wc_dir_name,)
 
-  if error_re_string:
-    rm = re.compile(error_re_string)
-    for line in errput:
-      match = rm.search(line)
-      if match:
-        return
-    raise main.SVNUnmatchedError
+  exit_code, output, errput = run_and_verify_svn(None, expected_stderr, 'up', *args)
 
   actual = wc.State.from_checkout(output)
   verify_update(actual, None, None, wc_dir_name,
                 output_tree, None, None, disk_tree, status_tree,
-                singleton_handler_a, a_baton,
-                singleton_handler_b, b_baton,
-                check_props)
+                check_props, keep_eol_style=keep_eol_style, **kw)
 
 
 def run_and_parse_info(*args):
@@ -959,19 +1089,20 @@ def run_and_verify_info(expected_infos, *args):
 
     for actual, expected in zip(actual_infos, expected_infos):
       # compare dicts
+      path = actual['Path']
       for key, value in expected.items():
         assert ':' not in key # caller passed impossible expectations?
         if value is None and key in actual:
-          raise main.SVNLineUnequal("Found unexpected key '%s' with value '%s'"
-                                    % (key, actual[key]))
+          raise main.SVNLineUnequal("On '%s': Found unexpected key '%s'\n  Value '%s'"
+                                    % (path, key, actual[key]))
         if value is not None and key not in actual:
-          raise main.SVNLineUnequal("Expected key '%s' (with value '%s') "
-                                    "not found" % (key, value))
+          raise main.SVNLineUnequal("On '%s': Expected key '%s' not found\n Expected value '%s'"
+                                    % (path, key, value))
         if value is not None and not re.match(value, actual[key]):
-          raise verify.SVNUnexpectedStdout("Values of key '%s' don't match:\n"
+          raise verify.SVNUnexpectedStdout("On '%s': Values of key '%s' don't match:\n"
                                            "  Expected: '%s' (regex)\n"
                                            "  Found:    '%s' (string)\n"
-                                           % (key, value, actual[key]))
+                                           % (path, key, value, actual[key]))
 
   except:
     sys.stderr.write("Bad 'svn info' output:\n"
@@ -985,24 +1116,38 @@ def run_and_verify_merge(dir, rev1, rev2, url1, url2,
                          mergeinfo_output_tree,
                          elision_output_tree,
                          disk_tree, status_tree, skip_tree,
-                         error_re_string = None,
-                         singleton_handler_a = None,
-                         a_baton = None,
-                         singleton_handler_b = None,
-                         b_baton = None,
+                         expected_stderr = [],
                          check_props = False,
                          dry_run = True,
-                         *args):
+                         *args, **kw):
+  """Same as run_and_verify_merge2 but with keep_eol_style set to False. """
+
+  run_and_verify_merge2(dir, rev1, rev2, url1, url2,
+                        output_tree,
+                        mergeinfo_output_tree,
+                        elision_output_tree,
+                        disk_tree, status_tree, skip_tree,
+                        expected_stderr,
+                        check_props,
+                        dry_run,
+                        False,
+                        *args, **kw)
+
+def run_and_verify_merge2(dir, rev1, rev2, url1, url2,
+                          output_tree,
+                          mergeinfo_output_tree,
+                          elision_output_tree,
+                          disk_tree, status_tree, skip_tree,
+                          expected_stderr = [],
+                          check_props = False,
+                          dry_run = True,
+                          keep_eol_style = False,
+                          *args, **kw):
   """Run 'svn merge URL1@REV1 URL2@REV2 DIR' if URL2 is not None
   (for a three-way merge between URLs and WC).
 
   If URL2 is None, run 'svn merge -rREV1:REV2 URL1 DIR'.  If both REV1
   and REV2 are None, leave off the '-r' argument.
-
-  If ERROR_RE_STRING, the merge must exit with error, and the error
-  message must match regular expression ERROR_RE_STRING.
-
-  Else if ERROR_RE_STRING is None, then:
 
   The subcommand output will be verified against OUTPUT_TREE.  Output
   related to mergeinfo notifications will be verified against
@@ -1020,6 +1165,10 @@ def run_and_verify_merge(dir, rev1, rev2, url1, url2,
 
   If DRY_RUN is set then a --dry-run merge will be carried out first and
   the output compared with that of the full merge.
+
+  If KEEP_EOL_STYLE is set, don't let Python normalize the EOL when
+  reading working copy contents as text files.  It has no effect on
+  binary files.
 
   Return if successful, raise on failure.
 
@@ -1040,12 +1189,12 @@ def run_and_verify_merge(dir, rev1, rev2, url1, url2,
   merge_command = tuple(merge_command)
 
   if dry_run:
-    pre_disk = tree.build_tree_from_wc(dir)
+    pre_disk = tree.build_tree_from_wc(dir, keep_eol_style=keep_eol_style)
     dry_run_command = merge_command + ('--dry-run',)
     dry_run_command = dry_run_command + args
-    exit_code, out_dry, err_dry = main.run_svn(error_re_string,
-                                               *dry_run_command)
-    post_disk = tree.build_tree_from_wc(dir)
+    exit_code, out_dry, err_dry = run_and_verify_svn(None, expected_stderr,
+                                                     *dry_run_command)
+    post_disk = tree.build_tree_from_wc(dir, keep_eol_style=keep_eol_style)
     try:
       tree.compare_trees("disk", post_disk, pre_disk)
     except tree.SVNTreeError:
@@ -1057,16 +1206,7 @@ def run_and_verify_merge(dir, rev1, rev2, url1, url2,
 
   # Update and make a tree of the output.
   merge_command = merge_command + args
-  exit_code, out, err = main.run_svn(error_re_string, *merge_command)
-
-  if error_re_string:
-    if not error_re_string.startswith(".*"):
-      error_re_string = ".*(" + error_re_string + ")"
-    expected_err = verify.RegexOutput(error_re_string, match_all=False)
-    verify.verify_outputs(None, None, err, None, expected_err)
-    return
-  elif err:
-    raise verify.SVNUnexpectedStderr(err)
+  exit_code, out, err = run_and_verify_svn(None, expected_stderr, *merge_command)
 
   # Split the output into that related to application of the actual diff
   # and that related to the recording of mergeinfo describing the merge.
@@ -1121,7 +1261,7 @@ def run_and_verify_merge(dir, rev1, rev2, url1, url2,
       for x in out_dry:
         logger.warn(x)
       logger.warn("The full merge output:")
-      for x in out:
+      for x in merge_diff_out:
         logger.warn(x)
       logger.warn("=============================================================")
       raise main.SVNUnmatchedError
@@ -1155,9 +1295,7 @@ def run_and_verify_merge(dir, rev1, rev2, url1, url2,
   verify_update(actual_diff, actual_mergeinfo, actual_elision, dir,
                 output_tree, mergeinfo_output_tree, elision_output_tree,
                 disk_tree, status_tree,
-                singleton_handler_a, a_baton,
-                singleton_handler_b, b_baton,
-                check_props)
+                check_props, keep_eol_style=keep_eol_style, **kw)
 
 
 def run_and_verify_patch(dir, patch_path,
@@ -1165,13 +1303,28 @@ def run_and_verify_patch(dir, patch_path,
                          error_re_string=None,
                          check_props=False,
                          dry_run=True,
-                         *args):
+                         *args, **kw):
+  """Same as run_and_verify_patch2 but with KEEP_EOL_STYLE set to False."""
+
+  run_and_verify_patch2(dir, patch_path,
+                        output_tree, disk_tree, status_tree, skip_tree,
+                        error_re_string,
+                        check_props,
+                        dry_run,
+                        False,
+                        *args, **kw)
+
+def run_and_verify_patch2(dir, patch_path,
+                          output_tree, disk_tree, status_tree, skip_tree,
+                          error_re_string=None,
+                          check_props=False,
+                          dry_run=True,
+                          keep_eol_style=False,
+                          *args, **kw):
   """Run 'svn patch patch_path DIR'.
 
   If ERROR_RE_STRING, 'svn patch' must exit with error, and the error
   message must match regular expression ERROR_RE_STRING.
-
-  Else if ERROR_RE_STRING is None, then:
 
   The subcommand output will be verified against OUTPUT_TREE, and the
   working copy itself will be verified against DISK_TREE.  If optional
@@ -1183,20 +1336,23 @@ def run_and_verify_patch(dir, patch_path,
   If DRY_RUN is set then a --dry-run patch will be carried out first and
   the output compared with that of the full patch application.
 
-  Returns if successful, raises on failure."""
+  If KEEP_EOL_STYLE is set, don't let Python normalize the EOL when
+  reading working copy contents as text files.  It has no effect on
+  binary files.
 
+  Returns if successful, raises on failure."""
   patch_command = [ "patch" ]
   patch_command.append(patch_path)
   patch_command.append(dir)
   patch_command = tuple(patch_command)
 
   if dry_run:
-    pre_disk = tree.build_tree_from_wc(dir)
+    pre_disk = tree.build_tree_from_wc(dir, keep_eol_style=keep_eol_style)
     dry_run_command = patch_command + ('--dry-run',)
     dry_run_command = dry_run_command + args
     exit_code, out_dry, err_dry = main.run_svn(error_re_string,
                                                *dry_run_command)
-    post_disk = tree.build_tree_from_wc(dir)
+    post_disk = tree.build_tree_from_wc(dir, keep_eol_style=keep_eol_style)
     try:
       tree.compare_trees("disk", post_disk, pre_disk)
     except tree.SVNTreeError:
@@ -1259,7 +1415,8 @@ def run_and_verify_patch(dir, patch_path,
 
   verify_update(mytree, None, None, dir,
                 output_tree, None, None, disk_tree, status_tree,
-                check_props=check_props)
+                check_props=check_props, keep_eol_style=keep_eol_style,
+                **kw)
 
 
 def run_and_verify_mergeinfo(error_re_string = None,
@@ -1282,7 +1439,6 @@ def run_and_verify_mergeinfo(error_re_string = None,
     return
 
   out = [_f for _f in [x.rstrip()[1:] for x in out] if _f]
-  expected_output.sort()
   extra_out = []
   if out != expected_output:
     exp_hash = dict.fromkeys(expected_output)
@@ -1303,20 +1459,11 @@ def run_and_verify_switch(wc_dir_name,
                           wc_target,
                           switch_url,
                           output_tree, disk_tree, status_tree,
-                          error_re_string = None,
-                          singleton_handler_a = None,
-                          a_baton = None,
-                          singleton_handler_b = None,
-                          b_baton = None,
+                          expected_stderr = [],
                           check_props = False,
-                          *args):
+                          *args, **kw):
 
   """Switch WC_TARGET (in working copy dir WC_DIR_NAME) to SWITCH_URL.
-
-  If ERROR_RE_STRING, the switch must exit with error, and the error
-  message must match regular expression ERROR_RE_STRING.
-
-  Else if ERROR_RE_STRING is None, then:
 
   The subcommand output will be verified against OUTPUT_TREE, and the
   working copy itself will be verified against DISK_TREE.  If optional
@@ -1324,36 +1471,21 @@ def run_and_verify_switch(wc_dir_name,
   compared.  (This is a good way to check that revision numbers were
   bumped.)
 
-  For the DISK_TREE verification, SINGLETON_HANDLER_A and
-  SINGLETON_HANDLER_B will be passed to tree.compare_trees -- see that
-  function's doc string for more details.
-
   If CHECK_PROPS is set, then disk comparison will examine props.
 
   Return if successful, raise on failure."""
 
   # Update and make a tree of the output.
-  exit_code, output, errput = main.run_svn(error_re_string, 'switch',
-                                           switch_url, wc_target, *args)
-
-  if error_re_string:
-    if not error_re_string.startswith(".*"):
-      error_re_string = ".*(" + error_re_string + ")"
-    expected_err = verify.RegexOutput(error_re_string, match_all=False)
-    verify.verify_outputs(None, None, errput, None, expected_err)
-    return
-  elif errput:
-    raise verify.SVNUnexpectedStderr(err)
-
+  exit_code, output, errput = run_and_verify_svn(None, expected_stderr,
+                                                 'switch', switch_url,
+                                                 wc_target, *args)
   actual = wc.State.from_checkout(output)
 
   verify_update(actual, None, None, wc_dir_name,
                 output_tree, None, None, disk_tree, status_tree,
-                singleton_handler_a, a_baton,
-                singleton_handler_b, b_baton,
-                check_props)
+                check_props, **kw)
 
-def process_output_for_commit(output):
+def process_output_for_commit(output, error_re_string):
   """Helper for run_and_verify_commit(), also used in the factory."""
   # Remove the final output line, and verify that the commit succeeded.
   lastline = ""
@@ -1372,7 +1504,7 @@ def process_output_for_commit(output):
 
     cm = re.compile("(Committed|Imported) revision [0-9]+.")
     match = cm.search(lastline)
-    if not match:
+    if not match and not error_re_string:
       logger.warn("ERROR:  commit did not succeed.")
       logger.warn("The final line from 'svn ci' was:")
       logger.warn(lastline)
@@ -1399,7 +1531,7 @@ def process_output_for_commit(output):
 
 
 def run_and_verify_commit(wc_dir_name, output_tree, status_tree,
-                          error_re_string = None,
+                          expected_stderr=[],
                           *args):
   """Commit and verify results within working copy WC_DIR_NAME,
   sending ARGS to the commit subcommand.
@@ -1409,44 +1541,34 @@ def run_and_verify_commit(wc_dir_name, output_tree, status_tree,
   be compared.  (This is a good way to check that revision numbers
   were bumped.)
 
-  If ERROR_RE_STRING is None, the commit must not exit with error.  If
-  ERROR_RE_STRING is a string, the commit must exit with error, and
-  the error message must match regular expression ERROR_RE_STRING.
+  EXPECTED_STDERR is handled as in run_and_verify_svn()
 
   Return if successful, raise on failure."""
 
   if isinstance(output_tree, wc.State):
     output_tree = output_tree.old_tree()
-  if isinstance(status_tree, wc.State):
-    status_tree = status_tree.old_tree()
 
   # Commit.
+  if len(args) == 0:
+    args = (wc_dir_name,)
   if '-m' not in args and '-F' not in args:
     args = list(args) + ['-m', 'log msg']
-  exit_code, output, errput = main.run_svn(error_re_string, 'ci',
-                                           *args)
-
-  if error_re_string:
-    if not error_re_string.startswith(".*"):
-      error_re_string = ".*(" + error_re_string + ")"
-    expected_err = verify.RegexOutput(error_re_string, match_all=False)
-    verify.verify_outputs(None, None, errput, None, expected_err)
-    return
-
-  # Else not expecting error:
+  exit_code, output, errput = run_and_verify_svn(None, expected_stderr,
+                                                 'ci', *args)
 
   # Convert the output into a tree.
-  output = process_output_for_commit(output)
+  output = process_output_for_commit(output, expected_stderr)
   actual = tree.build_tree_from_commit(output)
 
   # Verify actual output against expected output.
-  try:
-    tree.compare_trees("output", actual, output_tree)
-  except tree.SVNTreeError:
-      verify.display_trees("Output of commit is unexpected",
-                           "OUTPUT TREE", output_tree, actual)
-      _log_tree_state("ACTUAL OUTPUT TREE:", actual, wc_dir_name)
-      raise
+  if output_tree:
+    try:
+      tree.compare_trees("output", actual, output_tree)
+    except tree.SVNTreeError:
+        verify.display_trees("Output of commit is unexpected",
+                             "OUTPUT TREE", output_tree, actual)
+        _log_tree_state("ACTUAL OUTPUT TREE:", actual, wc_dir_name)
+        raise
 
   # Verify via 'status' command too, if possible.
   if status_tree:
@@ -1455,50 +1577,43 @@ def run_and_verify_commit(wc_dir_name, output_tree, status_tree,
 
 # This function always passes '-q' to the status command, which
 # suppresses the printing of any unversioned or nonexistent items.
-def run_and_verify_status(wc_dir_name, output_tree,
-                          singleton_handler_a = None,
-                          a_baton = None,
-                          singleton_handler_b = None,
-                          b_baton = None):
+def run_and_verify_status(wc_dir_name, status_tree, no_entries=False):
   """Run 'status' on WC_DIR_NAME and compare it with the
-  expected OUTPUT_TREE.  SINGLETON_HANDLER_A and SINGLETON_HANDLER_B will
-  be passed to tree.compare_trees - see that function's doc string for
-  more details.
+  expected STATUS_TREE.
   Returns on success, raises on failure."""
 
-  if isinstance(output_tree, wc.State):
-    output_state = output_tree
-    output_tree = output_tree.old_tree()
-  else:
-    output_state = None
+  if not isinstance(status_tree, wc.State):
+    raise TypeError('wc.State tree expected')
 
   exit_code, output, errput = main.run_svn(None, 'status', '-v', '-u', '-q',
                                            wc_dir_name)
 
-  actual = tree.build_tree_from_status(output)
+  actual_status = svntest.wc.State.from_status(output, wc_dir=wc_dir_name)
 
   # Verify actual output against expected output.
   try:
-    tree.compare_trees("status", actual, output_tree,
-                       singleton_handler_a, a_baton,
-                       singleton_handler_b, b_baton)
+    status_tree.compare_and_display('status', actual_status)
   except tree.SVNTreeError:
-    verify.display_trees(None, 'STATUS OUTPUT TREE', output_tree, actual)
-    _log_tree_state("ACTUAL STATUS TREE:", actual, wc_dir_name)
+    _log_tree_state("ACTUAL STATUS TREE:", actual_status.old_tree(),
+                                           wc_dir_name)
     raise
+
+  if no_entries:
+    return
 
   # if we have an output State, and we can/are-allowed to create an
   # entries-based State, then compare the two.
-  if output_state:
-    entries_state = wc.State.from_entries(wc_dir_name)
-    if entries_state:
-      tweaked = output_state.copy()
-      tweaked.tweak_for_entries_compare()
-      try:
-        tweaked.compare_and_display('entries', entries_state)
-      except tree.SVNTreeUnequal:
-        ### do something more
-        raise
+  actual_entries = wc.State.from_entries(wc_dir_name)
+  if actual_entries:
+    tweaked = status_tree.copy()
+    tweaked.tweak_for_entries_compare()
+    try:
+      tweaked.compare_and_display('entries', actual_entries)
+    except tree.SVNTreeUnequal:
+      ### do something more
+      _log_tree_state("ACTUAL ENTRY TREE:", actual_entries.old_tree(),
+                                           wc_dir_name)
+      raise
 
 
 # A variant of previous func, but doesn't pass '-q'.  This allows us
@@ -1508,19 +1623,20 @@ def run_and_verify_unquiet_status(wc_dir_name, status_tree):
   expected STATUS_TREE.
   Returns on success, raises on failure."""
 
-  if isinstance(status_tree, wc.State):
-    status_tree = status_tree.old_tree()
+  if not isinstance(status_tree, wc.State):
+    raise TypeError('wc.State tree expected')
 
   exit_code, output, errput = main.run_svn(None, 'status', '-v',
                                            '-u', wc_dir_name)
 
-  actual = tree.build_tree_from_status(output)
+  actual_status = svntest.wc.State.from_status(output, wc_dir=wc_dir_name)
 
   # Verify actual output against expected output.
   try:
-    tree.compare_trees("UNQUIET STATUS", actual, status_tree)
+    status_tree.compare_and_display('unquiet status', actual_status)
   except tree.SVNTreeError:
-    _log_tree_state("ACTUAL UNQUIET STATUS TREE:", actual, wc_dir_name)
+    _log_tree_state("ACTUAL STATUS TREE:",
+                    actual_status.normalize().old_tree(), wc_dir_name)
     raise
 
 def run_and_verify_status_xml(expected_entries = [],
@@ -1530,7 +1646,7 @@ def run_and_verify_status_xml(expected_entries = [],
   EXPECTED_ENTRIES.
   """
 
-  exit_code, output, errput = run_and_verify_svn(None, None, [],
+  exit_code, output, errput = run_and_verify_svn(None, [],
                                                  'status', '--xml', *args)
 
   if len(errput) > 0:
@@ -1573,6 +1689,90 @@ def run_and_verify_status_xml(expected_entries = [],
           pprint.pformat(expected_entries).splitlines(),
           pprint.pformat(actual_entries).splitlines())))
 
+def run_and_verify_inherited_prop_xml(path_or_url,
+                                      expected_inherited_props,
+                                      expected_explicit_props,
+                                      propname=None,
+                                      peg_rev=None,
+                                      *args):
+  """If PROPNAME is None, then call run_and_verify_svn with proplist -v --xml
+  --show-inherited-props on PATH_OR_URL, otherwise call run_and_verify_svn
+  with propget PROPNAME --xml --show-inherited-props.
+
+  PATH_OR_URL is pegged at PEG_REV if the latter is not None.  If PEG_REV
+  is none, then PATH_OR_URL is pegged at HEAD if a url.
+
+  EXPECTED_INHERITED_PROPS is a (possibly empty) dict mapping working copy
+  paths or URLs to dicts of inherited properties. EXPECTED_EXPLICIT_PROPS is
+  a (possibly empty) dict of the explicit properties expected on PATH_OR_URL.
+
+  Returns on success, raises on failure if EXPECTED_INHERITED_PROPS or
+  EXPECTED_EXPLICIT_PROPS don't match the results of proplist/propget.
+  """
+
+  if peg_rev is None:
+    if sandbox.is_url(path_or_url):
+      path_or_url = path_or_url + '@HEAD'
+  else:
+    path_or_url = path_or_url + '@' + str(peg_rev)
+
+  if (propname):
+    exit_code, output, errput = svntest.actions.run_and_verify_svn(
+      None, [], 'propget', propname, '--xml',
+      '--show-inherited-props', path_or_url, *args)
+  else:
+    exit_code, output, errput = svntest.actions.run_and_verify_svn(
+      None, [], 'proplist', '-v', '--xml', '--show-inherited-props',
+      path_or_url, *args)
+
+  if len(errput) > 0:
+    raise Failure
+
+  # Props inherited from within the WC are keyed on absolute paths.
+  expected_iprops = {}
+  for x in expected_inherited_props:
+    if sandbox.is_url(x):
+      expected_iprops[x] = expected_inherited_props[x]
+    else:
+      expected_iprops[os.path.abspath(x)] = expected_inherited_props[x]
+
+  actual_iprops = {}
+  actual_explicit_props = {}
+
+  doc = parseString(''.join(output))
+  targets = doc.getElementsByTagName('target')
+  for t in targets:
+
+    # Create actual inherited props.
+    iprops = t.getElementsByTagName('inherited_property')
+
+    if len(iprops) > 0:
+      actual_iprops[t.getAttribute('path')]={}
+
+    for i in iprops:
+      actual_iprops[t.getAttribute('path')][i.getAttribute('name')] = \
+        i.firstChild.nodeValue
+
+    # Create actual explicit props.
+    xprops = t.getElementsByTagName('property')
+
+    for x in xprops:
+      actual_explicit_props[x.getAttribute('name')] = x.firstChild.nodeValue
+
+  if expected_explicit_props != actual_explicit_props:
+    raise svntest.Failure(
+      'Actual and expected explicit props do not match\n' +
+      '\n'.join(difflib.ndiff(
+      pprint.pformat(expected_explicit_props).splitlines(),
+      pprint.pformat(actual_explicit_props).splitlines())))
+
+  if expected_iprops != actual_iprops:
+    raise svntest.Failure(
+      'Actual and expected inherited props do not match\n' +
+      '\n'.join(difflib.ndiff(
+      pprint.pformat(expected_iprops).splitlines(),
+      pprint.pformat(actual_iprops).splitlines())))
+
 def run_and_verify_diff_summarize_xml(error_re_string = [],
                                       expected_prefix = None,
                                       expected_paths = [],
@@ -1595,7 +1795,7 @@ def run_and_verify_diff_summarize_xml(error_re_string = [],
   EXPECTED_PROPS and EXPECTED_KINDS. Returns on success, raises
   on failure."""
 
-  exit_code, output, errput = run_and_verify_svn(None, None, error_re_string,
+  exit_code, output, errput = run_and_verify_svn(None, error_re_string,
                                                  'diff', '--summarize',
                                                  '--xml', *args)
 
@@ -1612,7 +1812,7 @@ def run_and_verify_diff_summarize_xml(error_re_string = [],
   for path in paths:
     modified_path = path.childNodes[0].data
 
-    if (expected_prefix is not None
+    if (expected_prefix
         and modified_path.find(expected_prefix) == 0):
       modified_path = modified_path.replace(expected_prefix, '')[1:].strip()
 
@@ -1679,16 +1879,16 @@ def run_and_validate_lock(path, username):
   comment = "Locking path:%s." % path
 
   # lock the path
-  run_and_verify_svn(None, ".*locked by user", [], 'lock',
+  run_and_verify_svn(".*locked by user", [], 'lock',
                      '--username', username,
                      '-m', comment, path)
 
   # Run info and check that we get the lock fields.
-  exit_code, output, err = run_and_verify_svn(None, None, [],
+  exit_code, output, err = run_and_verify_svn(None, [],
                                               'info','-R',
                                               path)
 
-  ### TODO: Leverage RegexOuput([...], match_all=True) here.
+  ### TODO: Leverage RegexOutput([...], match_all=True) here.
   # prepare the regexs to compare against
   token_re = re.compile(".*?Lock Token: opaquelocktoken:.*?", re.DOTALL)
   author_re = re.compile(".*?Lock Owner: %s\n.*?" % username, re.DOTALL)
@@ -1711,10 +1911,27 @@ def _run_and_verify_resolve(cmd, expected_paths, *args):
   # TODO: verify that the status of PATHS changes accordingly.
   if len(args) == 0:
     args = expected_paths
-  expected_output = verify.UnorderedOutput([
-    "Resolved conflicted state of '" + path + "'\n" for path in
-    expected_paths])
-  run_and_verify_svn(None, expected_output, [],
+  expected_output = verify.AlternateOutput([
+      verify.UnorderedOutput([
+        "Resolved conflicted state of '" + path + "'\n" for path in
+        expected_paths]),
+      verify.UnorderedOutput([
+        "Breaking move with source path '" + path + "'\n" for path in
+         expected_paths] + [
+        "Resolved conflicted state of '" + path + "'\n" for path in
+        expected_paths]),
+      verify.UnorderedOutput([
+        "Merge conflicts in '" + path + "' marked as resolved.\n" for path in
+        expected_paths]),
+      verify.UnorderedRegexListOutput([
+        "Conflict in property.*at '" + re.escape(path) + "' marked as resolved.\n" \
+        for path in expected_paths]),
+      verify.UnorderedOutput([
+        "Tree conflict at '" + path + "' marked as resolved.\n" for path in
+        expected_paths]),
+    ],
+    match_all=False)
+  run_and_verify_svn(expected_output, [],
                      cmd, *args)
 
 def run_and_verify_resolve(expected_paths, *args):
@@ -1738,7 +1955,7 @@ def run_and_verify_revert(expected_paths, *args):
   expected_output = verify.UnorderedOutput([
     "Reverted '" + path + "'\n" for path in
     expected_paths])
-  run_and_verify_svn(None, expected_output, [],
+  run_and_verify_svn(expected_output, [],
                      "revert", *args)
 
 
@@ -1747,32 +1964,52 @@ def run_and_verify_revert(expected_paths, *args):
 
 
 # This allows a test to *quickly* bootstrap itself.
-def make_repo_and_wc(sbox, create_wc = True, read_only = False,
-                     minor_version = None):
-  """Create a fresh 'Greek Tree' repository and check out a WC from it.
+def make_repo_and_wc(sbox, create_wc=True, read_only=False, empty=False,
+                     minor_version=None, tree=None):
+  """Create a fresh repository and check out a WC from it.  If EMPTY is
+  True, the repository and WC will be empty and at revision 0,
+  otherwise they will contain the 'Greek Tree' at revision 1.
 
   If READ_ONLY is False, a dedicated repository will be created, at the path
-  SBOX.repo_dir.  If READ_ONLY is True, the pristine repository will be used.
+  SBOX.repo_dir.  If READ_ONLY is True, a shared pristine repository may be
+  used or a dedicated repository may be created.  (Currently we use a shared
+  pristine 'Greek tree' repo but we create a dedicated empty repo.)
   In either case, SBOX.repo_url is assumed to point to the repository that
   will be used.
 
-  If create_wc is True, a dedicated working copy will be checked out from
+  If CREATE_WC is True, a dedicated working copy will be checked out from
   the repository, at the path SBOX.wc_dir.
 
   Returns on success, raises on failure."""
 
-  # Create (or copy afresh) a new repos with a greek tree in it.
-  if not read_only:
-    guarantee_greek_repository(sbox.repo_dir, minor_version)
+  # Create or copy or reference the appropriate kind of repository:
+  # if we want a non-empty, Greek repo, refer to the shared one; else
+  # if we want an empty repo or a writable Greek repo, create one.
+  # (We could have a shared empty repo for read-only use, but we don't.)
+  if empty:
+    guarantee_empty_repository(sbox.repo_dir, minor_version)
+    expected_state = svntest.wc.State('', {})
+  else:
+    if tree == 'greek':
+      if not read_only:
+        guarantee_greek_repository(sbox.repo_dir, minor_version)
+      expected_state = main.greek_state
+    elif tree == 'trojan':
+      if not read_only:
+        guarantee_trojan_repository(sbox.repo_dir, minor_version)
+      expected_state = main.trojan_state
+    else:
+      raise ValueError("'tree' must be 'greek' or 'trojan'"
+                       " but was '%s'" % str(tree))
 
   if create_wc:
     # Generate the expected output tree.
-    expected_output = main.greek_state.copy()
+    expected_output = expected_state.copy()
     expected_output.wc_dir = sbox.wc_dir
     expected_output.tweak(status='A ', contents=None)
 
     # Generate an expected wc tree.
-    expected_wc = main.greek_state
+    expected_wc = expected_state
 
     # Do a checkout, and verify the resulting output and disk contents.
     run_and_verify_checkout(sbox.repo_url,
@@ -1783,7 +2020,7 @@ def make_repo_and_wc(sbox, create_wc = True, read_only = False,
     # just make sure the parent folder of our working copy is created
     try:
       os.mkdir(main.general_wc_dir)
-    except OSError, err:
+    except OSError as err:
       if err.errno != errno.EEXIST:
         raise
 
@@ -1797,14 +2034,21 @@ def duplicate_dir(wc_name, wc_copy_name):
 
 
 
-def get_virginal_state(wc_dir, rev):
+def get_virginal_state(wc_dir, rev, tree='greek'):
   "Return a virginal greek tree state for a WC and repos at revision REV."
 
   rev = str(rev) ### maybe switch rev to an integer?
 
   # copy the greek tree, shift it to the new wc_dir, insert a root elem,
   # then tweak all values
-  state = main.greek_state.copy()
+  if tree == 'greek':
+    state = main.greek_state.copy()
+  elif tree == 'trojan':
+    state = main.trojan_state.copy()
+  else:
+    raise ValueError("'tree' must be 'greek' or 'trojan'"
+                     " but was '%s'" % str(tree))
+
   state.wc_dir = wc_dir
   state.desc[''] = wc.StateItem()
   state.tweak(contents=None, status='  ', wc_rev=rev)
@@ -1812,11 +2056,11 @@ def get_virginal_state(wc_dir, rev):
   return state
 
 # Cheap administrative directory locking
-def lock_admin_dir(wc_dir, recursive=False):
+def lock_admin_dir(wc_dir, recursive=False, work_queue=False):
   "Lock a SVN administrative directory"
   db, root_path, relpath = wc.open_wc_db(wc_dir)
 
-  svntest.main.run_wc_lock_tester(recursive, wc_dir)
+  svntest.main.run_wc_lock_tester(recursive, wc_dir, work_queue)
 
 def set_incomplete(wc_dir, revision):
   "Make wc_dir incomplete at revision"
@@ -1831,10 +2075,20 @@ def get_wc_base_rev(wc_dir):
   "Return the BASE revision of the working copy at WC_DIR."
   return run_and_parse_info(wc_dir)[0]['Revision']
 
+def load_dumpfile(filename):
+  "Return the contents of the FILENAME assuming that it is a dump file"
+  with open(filename, "rb") as fp:
+    dump_str = fp.readlines()
+  return dump_str
+
 def hook_failure_message(hook_name):
   """Return the error message that the client prints for failure of the
   specified hook HOOK_NAME. The wording changed with Subversion 1.5."""
-  if svntest.main.options.server_minor_version < 5:
+
+  # Output depends on the server version, not the repository version.
+  # This gets the wrong result for modern servers with old format
+  # repositories.
+  if svntest.main.options.server_minor_version < 5 and not svntest.main.is_ra_type_file():
     return "'%s' hook failed with error output:\n" % hook_name
   else:
     if hook_name in ["start-commit", "pre-commit"]:
@@ -1898,25 +2152,50 @@ def create_failing_post_commit_hook(repo_dir):
             '@echo Post-commit hook failed 1>&2\n'
             '@exit 1\n')
 
+def _make_temp_file(contents):
+  """ Create a unique temporary file with the specified CONTENTS
+  and return its path. """
+  from tempfile import mkstemp
+  (fd, path) = mkstemp()
+  os.close(fd)
+  file = open(path, 'wb')
+  file.write(contents)
+  file.flush()
+  file.close()
+  return path
+
 # set_prop can be used for properties with NULL characters which are not
 # handled correctly when passed to subprocess.Popen() and values like "*"
 # which are not handled correctly on Windows.
-def set_prop(name, value, path, expected_re_string=None):
+def set_prop(name, value, path, expected_re_string=None, force=None):
   """Set a property with specified value"""
-  if value and (value[0] == '-' or '\x00' in value or sys.platform == 'win32'):
-    from tempfile import mkstemp
-    (fd, value_file_path) = mkstemp()
-    os.close(fd)
-    value_file = open(value_file_path, 'wb')
-    value_file.write(value)
-    value_file.flush()
-    value_file.close()
-    exit_code, out, err = main.run_svn(expected_re_string, 'propset',
-                                       '-F', value_file_path, name, path)
-    os.remove(value_file_path)
+  if not force:
+    propset = ('propset',)
   else:
-    exit_code, out, err = main.run_svn(expected_re_string, 'propset',
-                                       name, value, path)
+    propset = ('propset', '--force')
+
+  if isinstance(value, bytes):
+    file = _make_temp_file(value)
+  elif isinstance(value, str):
+    if value and (value[0] == '-' or '\x00' in value or
+                  sys.platform == 'win32'):
+      file = _make_temp_file(value.encode())
+    else:
+      file = None
+  else:
+    raise TypeError(value)
+
+  if file is None:
+    propset += (name, value, path)
+  else:
+    propset += ('-F', file, name, path)
+
+  try:
+    exit_code, out, err = main.run_svn(expected_re_string, *propset)
+  finally:
+    if file is not None:
+      os.remove(file)
+
   if expected_re_string:
     if not expected_re_string.startswith(".*"):
       expected_re_string = ".*(" + expected_re_string + ")"
@@ -1932,7 +2211,7 @@ def check_prop(name, path, exp_out, revprop=None):
   else:
     revprop_options = []
   # Not using run_svn because binary_mode must be set
-  exit_code, out, err = main.run_command(main.svn_binary, None, 1, 'pg',
+  exit_code, out, err = main.run_command(main.svn_binary, None, True, 'pg',
                                          '--strict', name, path,
                                          '--config-dir',
                                          main.default_config_dir,
@@ -1989,7 +2268,7 @@ def inject_conflict_into_wc(sbox, state_path, file_path,
   if expected_status:
     expected_status.tweak(state_path, wc_rev=merged_rev)
   run_and_verify_commit(wc_dir, expected_output, expected_status,
-                        None, file_path)
+                        [], file_path)
 
   # Backdate the file.
   exit_code, output, errput = main.run_svn(None, "up", "-r", str(prev_rev),
@@ -2010,7 +2289,7 @@ def inject_conflict_into_wc(sbox, state_path, file_path,
   inject_conflict_into_expected_state(state_path,
                                       expected_disk, expected_status,
                                       conflicting_contents, contents,
-                                      merged_rev)
+                                      prev_rev, merged_rev)
   exit_code, output, errput = main.run_svn(None, "up", "-r", str(merged_rev),
                                            file_path)
   if expected_status:
@@ -2018,26 +2297,30 @@ def inject_conflict_into_wc(sbox, state_path, file_path,
 
 def inject_conflict_into_expected_state(state_path,
                                         expected_disk, expected_status,
-                                        wc_text, merged_text, merged_rev):
+                                        wc_text, merged_text, prev_rev,
+                                        merged_rev):
   """Update the EXPECTED_DISK and EXPECTED_STATUS trees for the
   conflict at STATE_PATH (ignored if None).  WC_TEXT, MERGED_TEXT, and
   MERGED_REV are used to determine the contents of the conflict (the
   text parameters should be newline-terminated)."""
   if expected_disk:
     conflict_marker = make_conflict_marker_text(wc_text, merged_text,
-                                                merged_rev)
+                                                prev_rev, merged_rev)
     existing_text = expected_disk.desc[state_path].contents or ""
     expected_disk.tweak(state_path, contents=existing_text + conflict_marker)
 
   if expected_status:
     expected_status.tweak(state_path, status='C ')
 
-def make_conflict_marker_text(wc_text, merged_text, merged_rev):
+def make_conflict_marker_text(wc_text, merged_text, prev_rev, merged_rev,
+                              old_text=''):
   """Return the conflict marker text described by WC_TEXT (the current
   text in the working copy, MERGED_TEXT (the conflicting text merged
   in), and MERGED_REV (the revision from whence the conflicting text
   came)."""
-  return "<<<<<<< .working\n" + wc_text + "=======\n" + \
+  return "<<<<<<< .working\n" + wc_text + \
+         "||||||| .merge-left.r" + str(prev_rev) + '\n' + \
+         old_text + "=======\n" + \
          merged_text + ">>>>>>> .merge-right.r" + str(merged_rev) + "\n"
 
 
@@ -2089,7 +2372,7 @@ def build_greek_tree_conflicts(sbox):
   expected_status = get_virginal_state(wc_dir, 1)
   expected_status.tweak('A/D/G/pi', wc_rev='2')
   expected_status.remove('A/D/G/rho', 'A/D/G/tau')
-  run_and_verify_commit(wc_dir, expected_output, expected_status, None,
+  run_and_verify_commit(wc_dir, expected_output, expected_status, [],
                         '-m', 'Incoming changes.', wc_dir )
 
   # Update back to the pristine state ("time-warp").
@@ -2101,7 +2384,7 @@ def build_greek_tree_conflicts(sbox):
   expected_disk = main.greek_state
   expected_status = get_virginal_state(wc_dir, 1)
   run_and_verify_update(wc_dir, expected_output, expected_disk,
-                        expected_status, None, None, None, None, None, False,
+                        expected_status, [], False,
                         '-r', '1', wc_dir)
 
   # Make local changes
@@ -2112,983 +2395,6 @@ def build_greek_tree_conflicts(sbox):
   # Update, receiving the incoming changes on top of the local changes,
   # causing tree conflicts.  Don't check for any particular result: that is
   # the job of other tests.
-  run_and_verify_svn(None, verify.AnyOutput, [], 'update', wc_dir)
-
-
-def make_deep_trees(base):
-  """Helper function for deep trees conflicts. Create a set of trees,
-  each in its own "container" dir. Any conflicts can be tested separately
-  in each container.
-  """
-  j = os.path.join
-  # Create the container dirs.
-  F   = j(base, 'F')
-  D   = j(base, 'D')
-  DF  = j(base, 'DF')
-  DD  = j(base, 'DD')
-  DDF = j(base, 'DDF')
-  DDD = j(base, 'DDD')
-  os.makedirs(F)
-  os.makedirs(j(D, 'D1'))
-  os.makedirs(j(DF, 'D1'))
-  os.makedirs(j(DD, 'D1', 'D2'))
-  os.makedirs(j(DDF, 'D1', 'D2'))
-  os.makedirs(j(DDD, 'D1', 'D2', 'D3'))
-
-  # Create their files.
-  alpha = j(F, 'alpha')
-  beta  = j(DF, 'D1', 'beta')
-  gamma = j(DDF, 'D1', 'D2', 'gamma')
-  main.file_append(alpha, "This is the file 'alpha'.\n")
-  main.file_append(beta, "This is the file 'beta'.\n")
-  main.file_append(gamma, "This is the file 'gamma'.\n")
-
-
-def add_deep_trees(sbox, base_dir_name):
-  """Prepare a "deep_trees" within a given directory.
-
-  The directory <sbox.wc_dir>/<base_dir_name> is created and a deep_tree
-  is created within. The items are only added, a commit has to be
-  called separately, if needed.
-
-  <base_dir_name> will thus be a container for the set of containers
-  mentioned in make_deep_trees().
-  """
-  j = os.path.join
-  base = j(sbox.wc_dir, base_dir_name)
-  make_deep_trees(base)
-  main.run_svn(None, 'add', base)
-
-
-Item = wc.StateItem
-
-# initial deep trees state
-deep_trees_virginal_state = wc.State('', {
-  'F'               : Item(),
-  'F/alpha'         : Item("This is the file 'alpha'.\n"),
-  'D'               : Item(),
-  'D/D1'            : Item(),
-  'DF'              : Item(),
-  'DF/D1'           : Item(),
-  'DF/D1/beta'      : Item("This is the file 'beta'.\n"),
-  'DD'              : Item(),
-  'DD/D1'           : Item(),
-  'DD/D1/D2'        : Item(),
-  'DDF'             : Item(),
-  'DDF/D1'          : Item(),
-  'DDF/D1/D2'       : Item(),
-  'DDF/D1/D2/gamma' : Item("This is the file 'gamma'.\n"),
-  'DDD'             : Item(),
-  'DDD/D1'          : Item(),
-  'DDD/D1/D2'       : Item(),
-  'DDD/D1/D2/D3'    : Item(),
-  })
-
-
-# Many actions on deep trees and their resulting states...
-
-def deep_trees_leaf_edit(base):
-  """Helper function for deep trees test cases. Append text to files,
-  create new files in empty directories, and change leaf node properties."""
-  j = os.path.join
-  F   = j(base, 'F', 'alpha')
-  DF  = j(base, 'DF', 'D1', 'beta')
-  DDF = j(base, 'DDF', 'D1', 'D2', 'gamma')
-  main.file_append(F, "More text for file alpha.\n")
-  main.file_append(DF, "More text for file beta.\n")
-  main.file_append(DDF, "More text for file gamma.\n")
-  run_and_verify_svn(None, verify.AnyOutput, [],
-                     'propset', 'prop1', '1', F, DF, DDF)
-
-  D   = j(base, 'D', 'D1')
-  DD  = j(base, 'DD', 'D1', 'D2')
-  DDD = j(base, 'DDD', 'D1', 'D2', 'D3')
-  run_and_verify_svn(None, verify.AnyOutput, [],
-                     'propset', 'prop1', '1', D, DD, DDD)
-  D   = j(base, 'D', 'D1', 'delta')
-  DD  = j(base, 'DD', 'D1', 'D2', 'epsilon')
-  DDD = j(base, 'DDD', 'D1', 'D2', 'D3', 'zeta')
-  main.file_append(D, "This is the file 'delta'.\n")
-  main.file_append(DD, "This is the file 'epsilon'.\n")
-  main.file_append(DDD, "This is the file 'zeta'.\n")
-  run_and_verify_svn(None, verify.AnyOutput, [],
-                     'add', D, DD, DDD)
-
-# deep trees state after a call to deep_trees_leaf_edit
-deep_trees_after_leaf_edit = wc.State('', {
-  'F'                 : Item(),
-  'F/alpha'           : Item("This is the file 'alpha'.\nMore text for file alpha.\n"),
-  'D'                 : Item(),
-  'D/D1'              : Item(),
-  'D/D1/delta'        : Item("This is the file 'delta'.\n"),
-  'DF'                : Item(),
-  'DF/D1'             : Item(),
-  'DF/D1/beta'        : Item("This is the file 'beta'.\nMore text for file beta.\n"),
-  'DD'                : Item(),
-  'DD/D1'             : Item(),
-  'DD/D1/D2'          : Item(),
-  'DD/D1/D2/epsilon'  : Item("This is the file 'epsilon'.\n"),
-  'DDF'               : Item(),
-  'DDF/D1'            : Item(),
-  'DDF/D1/D2'         : Item(),
-  'DDF/D1/D2/gamma'   : Item("This is the file 'gamma'.\nMore text for file gamma.\n"),
-  'DDD'               : Item(),
-  'DDD/D1'            : Item(),
-  'DDD/D1/D2'         : Item(),
-  'DDD/D1/D2/D3'      : Item(),
-  'DDD/D1/D2/D3/zeta' : Item("This is the file 'zeta'.\n"),
-  })
-
-
-def deep_trees_leaf_del(base):
-  """Helper function for deep trees test cases. Delete files and empty
-  dirs."""
-  j = os.path.join
-  F   = j(base, 'F', 'alpha')
-  D   = j(base, 'D', 'D1')
-  DF  = j(base, 'DF', 'D1', 'beta')
-  DD  = j(base, 'DD', 'D1', 'D2')
-  DDF = j(base, 'DDF', 'D1', 'D2', 'gamma')
-  DDD = j(base, 'DDD', 'D1', 'D2', 'D3')
-  main.run_svn(None, 'rm', F, D, DF, DD, DDF, DDD)
-
-# deep trees state after a call to deep_trees_leaf_del
-deep_trees_after_leaf_del = wc.State('', {
-  'F'               : Item(),
-  'D'               : Item(),
-  'DF'              : Item(),
-  'DF/D1'           : Item(),
-  'DD'              : Item(),
-  'DD/D1'           : Item(),
-  'DDF'             : Item(),
-  'DDF/D1'          : Item(),
-  'DDF/D1/D2'       : Item(),
-  'DDD'             : Item(),
-  'DDD/D1'          : Item(),
-  'DDD/D1/D2'       : Item(),
-  })
-
-# deep trees state after a call to deep_trees_leaf_del with no commit
-def deep_trees_after_leaf_del_no_ci(wc_dir):
-  if svntest.main.wc_is_singledb(wc_dir):
-    return deep_trees_after_leaf_del
-  else:
-    return deep_trees_empty_dirs
-
-
-def deep_trees_tree_del(base):
-  """Helper function for deep trees test cases.  Delete top-level dirs."""
-  j = os.path.join
-  F   = j(base, 'F', 'alpha')
-  D   = j(base, 'D', 'D1')
-  DF  = j(base, 'DF', 'D1')
-  DD  = j(base, 'DD', 'D1')
-  DDF = j(base, 'DDF', 'D1')
-  DDD = j(base, 'DDD', 'D1')
-  main.run_svn(None, 'rm', F, D, DF, DD, DDF, DDD)
-
-def deep_trees_rmtree(base):
-  """Helper function for deep trees test cases.  Delete top-level dirs
-     with rmtree instead of svn del."""
-  j = os.path.join
-  F   = j(base, 'F', 'alpha')
-  D   = j(base, 'D', 'D1')
-  DF  = j(base, 'DF', 'D1')
-  DD  = j(base, 'DD', 'D1')
-  DDF = j(base, 'DDF', 'D1')
-  DDD = j(base, 'DDD', 'D1')
-  os.unlink(F)
-  main.safe_rmtree(D)
-  main.safe_rmtree(DF)
-  main.safe_rmtree(DD)
-  main.safe_rmtree(DDF)
-  main.safe_rmtree(DDD)
-
-# deep trees state after a call to deep_trees_tree_del
-deep_trees_after_tree_del = wc.State('', {
-  'F'                 : Item(),
-  'D'                 : Item(),
-  'DF'                : Item(),
-  'DD'                : Item(),
-  'DDF'               : Item(),
-  'DDD'               : Item(),
-  })
-
-# deep trees state without any files
-deep_trees_empty_dirs = wc.State('', {
-  'F'               : Item(),
-  'D'               : Item(),
-  'D/D1'            : Item(),
-  'DF'              : Item(),
-  'DF/D1'           : Item(),
-  'DD'              : Item(),
-  'DD/D1'           : Item(),
-  'DD/D1/D2'        : Item(),
-  'DDF'             : Item(),
-  'DDF/D1'          : Item(),
-  'DDF/D1/D2'       : Item(),
-  'DDD'             : Item(),
-  'DDD/D1'          : Item(),
-  'DDD/D1/D2'       : Item(),
-  'DDD/D1/D2/D3'    : Item(),
-  })
-
-# deep trees state after a call to deep_trees_tree_del with no commit
-def deep_trees_after_tree_del_no_ci(wc_dir):
-  if svntest.main.wc_is_singledb(wc_dir):
-    return deep_trees_after_tree_del
-  else:
-    return deep_trees_empty_dirs
-
-def deep_trees_tree_del_repos(base):
-  """Helper function for deep trees test cases.  Delete top-level dirs,
-  directly in the repository."""
-  j = '/'.join
-  F   = j([base, 'F', 'alpha'])
-  D   = j([base, 'D', 'D1'])
-  DF  = j([base, 'DF', 'D1'])
-  DD  = j([base, 'DD', 'D1'])
-  DDF = j([base, 'DDF', 'D1'])
-  DDD = j([base, 'DDD', 'D1'])
-  main.run_svn(None, 'mkdir', '-m', '', F, D, DF, DD, DDF, DDD)
-
-# Expected merge/update/switch output.
-
-deep_trees_conflict_output = wc.State('', {
-  'F/alpha'           : Item(status='  ', treeconflict='C'),
-  'D/D1'              : Item(status='  ', treeconflict='C'),
-  'DF/D1'             : Item(status='  ', treeconflict='C'),
-  'DD/D1'             : Item(status='  ', treeconflict='C'),
-  'DDF/D1'            : Item(status='  ', treeconflict='C'),
-  'DDD/D1'            : Item(status='  ', treeconflict='C'),
-  })
-
-deep_trees_conflict_output_skipped = wc.State('', {
-  'D/D1'              : Item(verb='Skipped'),
-  'F/alpha'           : Item(verb='Skipped'),
-  'DD/D1'             : Item(verb='Skipped'),
-  'DF/D1'             : Item(verb='Skipped'),
-  'DDD/D1'            : Item(verb='Skipped'),
-  'DDF/D1'            : Item(verb='Skipped'),
-  })
-
-# Expected status output after merge/update/switch.
-
-deep_trees_status_local_tree_del = wc.State('', {
-  ''                  : Item(status='  ', wc_rev=3),
-  'D'                 : Item(status='  ', wc_rev=3),
-  'D/D1'              : Item(status='D ', wc_rev=2, treeconflict='C'),
-  'DD'                : Item(status='  ', wc_rev=3),
-  'DD/D1'             : Item(status='D ', wc_rev=2, treeconflict='C'),
-  'DD/D1/D2'          : Item(status='D ', wc_rev=2),
-  'DDD'               : Item(status='  ', wc_rev=3),
-  'DDD/D1'            : Item(status='D ', wc_rev=2, treeconflict='C'),
-  'DDD/D1/D2'         : Item(status='D ', wc_rev=2),
-  'DDD/D1/D2/D3'      : Item(status='D ', wc_rev=2),
-  'DDF'               : Item(status='  ', wc_rev=3),
-  'DDF/D1'            : Item(status='D ', wc_rev=2, treeconflict='C'),
-  'DDF/D1/D2'         : Item(status='D ', wc_rev=2),
-  'DDF/D1/D2/gamma'   : Item(status='D ', wc_rev=2),
-  'DF'                : Item(status='  ', wc_rev=3),
-  'DF/D1'             : Item(status='D ', wc_rev=2, treeconflict='C'),
-  'DF/D1/beta'        : Item(status='D ', wc_rev=2),
-  'F'                 : Item(status='  ', wc_rev=3),
-  'F/alpha'           : Item(status='D ', wc_rev=2, treeconflict='C'),
-  })
-
-deep_trees_status_local_leaf_edit = wc.State('', {
-  ''                  : Item(status='  ', wc_rev=3),
-  'D'                 : Item(status='  ', wc_rev=3),
-  'D/D1'              : Item(status=' M', wc_rev=2, treeconflict='C'),
-  'D/D1/delta'        : Item(status='A ', wc_rev=0),
-  'DD'                : Item(status='  ', wc_rev=3),
-  'DD/D1'             : Item(status='  ', wc_rev=2, treeconflict='C'),
-  'DD/D1/D2'          : Item(status=' M', wc_rev=2),
-  'DD/D1/D2/epsilon'  : Item(status='A ', wc_rev=0),
-  'DDD'               : Item(status='  ', wc_rev=3),
-  'DDD/D1'            : Item(status='  ', wc_rev=2, treeconflict='C'),
-  'DDD/D1/D2'         : Item(status='  ', wc_rev=2),
-  'DDD/D1/D2/D3'      : Item(status=' M', wc_rev=2),
-  'DDD/D1/D2/D3/zeta' : Item(status='A ', wc_rev=0),
-  'DDF'               : Item(status='  ', wc_rev=3),
-  'DDF/D1'            : Item(status='  ', wc_rev=2, treeconflict='C'),
-  'DDF/D1/D2'         : Item(status='  ', wc_rev=2),
-  'DDF/D1/D2/gamma'   : Item(status='MM', wc_rev=2),
-  'DF'                : Item(status='  ', wc_rev=3),
-  'DF/D1'             : Item(status='  ', wc_rev=2, treeconflict='C'),
-  'DF/D1/beta'        : Item(status='MM', wc_rev=2),
-  'F'                 : Item(status='  ', wc_rev=3),
-  'F/alpha'           : Item(status='MM', wc_rev=2, treeconflict='C'),
-  })
-
-
-class DeepTreesTestCase:
-  """Describes one tree-conflicts test case.
-  See deep_trees_run_tests_scheme_for_update(), ..._switch(), ..._merge().
-
-  The name field is the subdirectory name in which the test should be run.
-
-  The local_action and incoming_action are the functions to run
-  to construct the local changes and incoming changes, respectively.
-  See deep_trees_leaf_edit, deep_trees_tree_del, etc.
-
-  The expected_* and error_re_string arguments are described in functions
-  run_and_verify_[update|switch|merge]
-  except expected_info, which is a dict that has path keys with values
-  that are dicts as passed to run_and_verify_info():
-    expected_info = {
-      'F/alpha' : {
-        'Revision' : '3',
-        'Tree conflict' :
-          '^local delete, incoming edit upon update'
-          + ' Source  left: .file.*/F/alpha@2'
-          + ' Source right: .file.*/F/alpha@3$',
-      },
-      'DF/D1' : {
-        'Tree conflict' :
-          '^local delete, incoming edit upon update'
-          + ' Source  left: .dir.*/DF/D1@2'
-          + ' Source right: .dir.*/DF/D1@3$',
-      },
-      ...
-    }
-
-  Note: expected_skip is only used in merge, i.e. using
-  deep_trees_run_tests_scheme_for_merge.
-  """
-
-  def __init__(self, name, local_action, incoming_action,
-                expected_output = None, expected_disk = None,
-                expected_status = None, expected_skip = None,
-                error_re_string = None,
-                commit_block_string = ".*remains in conflict.*",
-                expected_info = None):
-    self.name = name
-    self.local_action = local_action
-    self.incoming_action = incoming_action
-    self.expected_output = expected_output
-    self.expected_disk = expected_disk
-    self.expected_status = expected_status
-    self.expected_skip = expected_skip
-    self.error_re_string = error_re_string
-    self.commit_block_string = commit_block_string
-    self.expected_info = expected_info
-
-
-
-def deep_trees_run_tests_scheme_for_update(sbox, greater_scheme):
-  """
-  Runs a given list of tests for conflicts occuring at an update operation.
-
-  This function wants to save time and perform a number of different
-  test cases using just a single repository and performing just one commit
-  for all test cases instead of one for each test case.
-
-   1) Each test case is initialized in a separate subdir. Each subdir
-      again contains one set of "deep_trees", being separate container
-      dirs for different depths of trees (F, D, DF, DD, DDF, DDD).
-
-   2) A commit is performed across all test cases and depths.
-      (our initial state, -r2)
-
-   3) In each test case subdir (e.g. "local_tree_del_incoming_leaf_edit"),
-      its *incoming* action is performed (e.g. "deep_trees_leaf_edit"), in
-      each of the different depth trees (F, D, DF, ... DDD).
-
-   4) A commit is performed across all test cases and depths:
-      our "incoming" state is "stored away in the repository for now",
-      -r3.
-
-   5) All test case dirs and contained deep_trees are time-warped
-      (updated) back to -r2, the initial state containing deep_trees.
-
-   6) In each test case subdir (e.g. "local_tree_del_incoming_leaf_edit"),
-      its *local* action is performed (e.g. "deep_trees_leaf_del"), in
-      each of the different depth trees (F, D, DF, ... DDD).
-
-   7) An update to -r3 is performed across all test cases and depths.
-      This causes tree-conflicts between the "local" state in the working
-      copy and the "incoming" state from the repository, -r3.
-
-   8) A commit is performed in each separate container, to verify
-      that each tree-conflict indeed blocks a commit.
-
-  The sbox parameter is just the sbox passed to a test function. No need
-  to call sbox.build(), since it is called (once) within this function.
-
-  The "table" greater_scheme models all of the different test cases
-  that should be run using a single repository.
-
-  greater_scheme is a list of DeepTreesTestCase items, which define complete
-  test setups, so that they can be performed as described above.
-  """
-
-  j = os.path.join
-
-  if not sbox.is_built():
-    sbox.build()
-  wc_dir = sbox.wc_dir
-
-
-  # 1) create directories
-
-  for test_case in greater_scheme:
-    try:
-      add_deep_trees(sbox, test_case.name)
-    except:
-      logger.warn("ERROR IN: Tests scheme for update: "
-          + "while setting up deep trees in '%s'", test_case.name)
-      raise
-
-
-  # 2) commit initial state
-
-  main.run_svn(None, 'commit', '-m', 'initial state', wc_dir)
-
-
-  # 3) apply incoming changes
-
-  for test_case in greater_scheme:
-    try:
-      test_case.incoming_action(j(sbox.wc_dir, test_case.name))
-    except:
-      logger.warn("ERROR IN: Tests scheme for update: "
-          + "while performing incoming action in '%s'", test_case.name)
-      raise
-
-
-  # 4) commit incoming changes
-
-  main.run_svn(None, 'commit', '-m', 'incoming changes', wc_dir)
-
-
-  # 5) time-warp back to -r2
-
-  main.run_svn(None, 'update', '-r2', wc_dir)
-
-
-  # 6) apply local changes
-
-  for test_case in greater_scheme:
-    try:
-      test_case.local_action(j(wc_dir, test_case.name))
-    except:
-      logger.warn("ERROR IN: Tests scheme for update: "
-          + "while performing local action in '%s'", test_case.name)
-      raise
-
-
-  # 7) update to -r3, conflicting with incoming changes.
-  #    A lot of different things are expected.
-  #    Do separate update operations for each test case.
-
-  for test_case in greater_scheme:
-    try:
-      base = j(wc_dir, test_case.name)
-
-      x_out = test_case.expected_output
-      if x_out != None:
-        x_out = x_out.copy()
-        x_out.wc_dir = base
-
-      x_disk = test_case.expected_disk
-
-      x_status = test_case.expected_status
-      if x_status != None:
-        x_status.copy()
-        x_status.wc_dir = base
-
-      run_and_verify_update(base, x_out, x_disk, None,
-                            error_re_string = test_case.error_re_string)
-      if x_status:
-        run_and_verify_unquiet_status(base, x_status)
-
-      x_info = test_case.expected_info or {}
-      for path in x_info:
-        run_and_verify_info([x_info[path]], j(base, path))
-
-    except:
-      logger.warn("ERROR IN: Tests scheme for update: "
-          + "while verifying in '%s'", test_case.name)
-      raise
-
-
-  # 8) Verify that commit fails.
-
-  for test_case in greater_scheme:
-    try:
-      base = j(wc_dir, test_case.name)
-
-      x_status = test_case.expected_status
-      if x_status != None:
-        x_status.copy()
-        x_status.wc_dir = base
-
-      run_and_verify_commit(base, None, x_status,
-                            test_case.commit_block_string,
-                            base)
-    except:
-      logger.warn("ERROR IN: Tests scheme for update: "
-          + "while checking commit-blocking in '%s'", test_case.name)
-      raise
-
-
-
-def deep_trees_skipping_on_update(sbox, test_case, skip_paths,
-                                  chdir_skip_paths):
-  """
-  Create tree conflicts, then update again, expecting the existing tree
-  conflicts to be skipped.
-  SKIP_PATHS is a list of paths, relative to the "base dir", for which
-  "update" on the "base dir" should report as skipped.
-  CHDIR_SKIP_PATHS is a list of (target-path, skipped-path) pairs for which
-  an update of "target-path" (relative to the "base dir") should result in
-  "skipped-path" (relative to "target-path") being reported as skipped.
-  """
-
-  """FURTHER_ACTION is a function that will make a further modification to
-  each target, this being the modification that we expect to be skipped. The
-  function takes the "base dir" (the WC path to the test case directory) as
-  its only argument."""
-  further_action = deep_trees_tree_del_repos
-
-  j = os.path.join
-  wc_dir = sbox.wc_dir
-  base = j(wc_dir, test_case.name)
-
-  # Initialize: generate conflicts. (We do not check anything here.)
-  setup_case = DeepTreesTestCase(test_case.name,
-                                 test_case.local_action,
-                                 test_case.incoming_action,
-                                 None,
-                                 None,
-                                 None)
-  deep_trees_run_tests_scheme_for_update(sbox, [setup_case])
-
-  # Make a further change to each target in the repository so there is a new
-  # revision to update to. (This is r4.)
-  further_action(sbox.repo_url + '/' + test_case.name)
-
-  # Update whole working copy, expecting the nodes still in conflict to be
-  # skipped.
-
-  x_out = test_case.expected_output
-  if x_out != None:
-    x_out = x_out.copy()
-    x_out.wc_dir = base
-
-  x_disk = test_case.expected_disk
-
-  x_status = test_case.expected_status
-  if x_status != None:
-    x_status = x_status.copy()
-    x_status.wc_dir = base
-    # Account for nodes that were updated by further_action
-    x_status.tweak('', 'D', 'F', 'DD', 'DF', 'DDD', 'DDF', wc_rev=4)
-
-  run_and_verify_update(base, x_out, x_disk, None,
-                        error_re_string = test_case.error_re_string)
-
-  run_and_verify_unquiet_status(base, x_status)
-
-  # Try to update each in-conflict subtree. Expect a 'Skipped' output for
-  # each, and the WC status to be unchanged.
-  for path in skip_paths:
-    run_and_verify_update(j(base, path),
-                          wc.State(base, {path : Item(verb='Skipped')}),
-                          None, None)
-
-  run_and_verify_unquiet_status(base, x_status)
-
-  # Try to update each in-conflict subtree. Expect a 'Skipped' output for
-  # each, and the WC status to be unchanged.
-  # This time, cd to the subdir before updating it.
-  was_cwd = os.getcwd()
-  for path, skipped in chdir_skip_paths:
-    if isinstance(skipped, list):
-      expected_skip = {}
-      for p in skipped:
-        expected_skip[p] = Item(verb='Skipped')
-    else:
-      expected_skip = {skipped : Item(verb='Skipped')}
-    p = j(base, path)
-    run_and_verify_update(p,
-                          wc.State(p, expected_skip),
-                          None, None)
-  os.chdir(was_cwd)
-
-  run_and_verify_unquiet_status(base, x_status)
-
-  # Verify that commit still fails.
-  for path, skipped in chdir_skip_paths:
-
-    run_and_verify_commit(j(base, path), None, None,
-                          test_case.commit_block_string,
-                          base)
-
-  run_and_verify_unquiet_status(base, x_status)
-
-
-def deep_trees_run_tests_scheme_for_switch(sbox, greater_scheme):
-  """
-  Runs a given list of tests for conflicts occuring at a switch operation.
-
-  This function wants to save time and perform a number of different
-  test cases using just a single repository and performing just one commit
-  for all test cases instead of one for each test case.
-
-   1) Each test case is initialized in a separate subdir. Each subdir
-      again contains two subdirs: one "local" and one "incoming" for
-      the switch operation. These contain a set of deep_trees each.
-
-   2) A commit is performed across all test cases and depths.
-      (our initial state, -r2)
-
-   3) In each test case subdir's incoming subdir, the
-      incoming actions are performed.
-
-   4) A commit is performed across all test cases and depths. (-r3)
-
-   5) In each test case subdir's local subdir, the local actions are
-      performed. They remain uncommitted in the working copy.
-
-   6) In each test case subdir's local dir, a switch is performed to its
-      corresponding incoming dir.
-      This causes conflicts between the "local" state in the working
-      copy and the "incoming" state from the incoming subdir (still -r3).
-
-   7) A commit is performed in each separate container, to verify
-      that each tree-conflict indeed blocks a commit.
-
-  The sbox parameter is just the sbox passed to a test function. No need
-  to call sbox.build(), since it is called (once) within this function.
-
-  The "table" greater_scheme models all of the different test cases
-  that should be run using a single repository.
-
-  greater_scheme is a list of DeepTreesTestCase items, which define complete
-  test setups, so that they can be performed as described above.
-  """
-
-  j = os.path.join
-
-  if not sbox.is_built():
-    sbox.build()
-  wc_dir = sbox.wc_dir
-
-
-  # 1) Create directories.
-
-  for test_case in greater_scheme:
-    try:
-      base = j(sbox.wc_dir, test_case.name)
-      os.makedirs(base)
-      make_deep_trees(j(base, "local"))
-      make_deep_trees(j(base, "incoming"))
-      main.run_svn(None, 'add', base)
-    except:
-      logger.warn("ERROR IN: Tests scheme for switch: "
-          + "while setting up deep trees in '%s'", test_case.name)
-      raise
-
-
-  # 2) Commit initial state (-r2).
-
-  main.run_svn(None, 'commit', '-m', 'initial state', wc_dir)
-
-
-  # 3) Apply incoming changes
-
-  for test_case in greater_scheme:
-    try:
-      test_case.incoming_action(j(sbox.wc_dir, test_case.name, "incoming"))
-    except:
-      logger.warn("ERROR IN: Tests scheme for switch: "
-          + "while performing incoming action in '%s'", test_case.name)
-      raise
-
-
-  # 4) Commit all changes (-r3).
-
-  main.run_svn(None, 'commit', '-m', 'incoming changes', wc_dir)
-
-
-  # 5) Apply local changes in their according subdirs.
-
-  for test_case in greater_scheme:
-    try:
-      test_case.local_action(j(sbox.wc_dir, test_case.name, "local"))
-    except:
-      logger.warn("ERROR IN: Tests scheme for switch: "
-          + "while performing local action in '%s'", test_case.name)
-      raise
-
-
-  # 6) switch the local dir to the incoming url, conflicting with incoming
-  #    changes. A lot of different things are expected.
-  #    Do separate switch operations for each test case.
-
-  for test_case in greater_scheme:
-    try:
-      local = j(wc_dir, test_case.name, "local")
-      incoming = sbox.repo_url + "/" + test_case.name + "/incoming"
-
-      x_out = test_case.expected_output
-      if x_out != None:
-        x_out = x_out.copy()
-        x_out.wc_dir = local
-
-      x_disk = test_case.expected_disk
-
-      x_status = test_case.expected_status
-      if x_status != None:
-        x_status.copy()
-        x_status.wc_dir = local
-
-      run_and_verify_switch(local, local, incoming, x_out, x_disk, None,
-                            test_case.error_re_string, None, None, None,
-                            None, False, '--ignore-ancestry')
-      run_and_verify_unquiet_status(local, x_status)
-
-      x_info = test_case.expected_info or {}
-      for path in x_info:
-        run_and_verify_info([x_info[path]], j(local, path))
-    except:
-      logger.warn("ERROR IN: Tests scheme for switch: "
-          + "while verifying in '%s'", test_case.name)
-      raise
-
-
-  # 7) Verify that commit fails.
-
-  for test_case in greater_scheme:
-    try:
-      local = j(wc_dir, test_case.name, 'local')
-
-      x_status = test_case.expected_status
-      if x_status != None:
-        x_status.copy()
-        x_status.wc_dir = local
-
-      run_and_verify_commit(local, None, x_status,
-                            test_case.commit_block_string,
-                            local)
-    except:
-      logger.warn("ERROR IN: Tests scheme for switch: "
-          + "while checking commit-blocking in '%s'", test_case.name)
-      raise
-
-
-def deep_trees_run_tests_scheme_for_merge(sbox, greater_scheme,
-                                          do_commit_local_changes,
-                                          do_commit_conflicts=True,
-                                          ignore_ancestry=False):
-  """
-  Runs a given list of tests for conflicts occuring at a merge operation.
-
-  This function wants to save time and perform a number of different
-  test cases using just a single repository and performing just one commit
-  for all test cases instead of one for each test case.
-
-   1) Each test case is initialized in a separate subdir. Each subdir
-      initially contains another subdir, called "incoming", which
-      contains a set of deep_trees.
-
-   2) A commit is performed across all test cases and depths.
-      (a pre-initial state)
-
-   3) In each test case subdir, the "incoming" subdir is copied to "local",
-      via the `svn copy' command. Each test case's subdir now has two sub-
-      dirs: "local" and "incoming", initial states for the merge operation.
-
-   4) An update is performed across all test cases and depths, so that the
-      copies made in 3) are pulled into the wc.
-
-   5) In each test case's "incoming" subdir, the incoming action is
-      performed.
-
-   6) A commit is performed across all test cases and depths, to commit
-      the incoming changes.
-      If do_commit_local_changes is True, this becomes step 7 (swap steps).
-
-   7) In each test case's "local" subdir, the local_action is performed.
-      If do_commit_local_changes is True, this becomes step 6 (swap steps).
-      Then, in effect, the local changes are committed as well.
-
-   8) In each test case subdir, the "incoming" subdir is merged into the
-      "local" subdir.  If ignore_ancestry is True, then the merge is done
-      with the --ignore-ancestry option, so mergeinfo is neither considered
-      nor recorded.  This causes conflicts between the "local" state in the
-      working copy and the "incoming" state from the incoming subdir.
-
-   9) If do_commit_conflicts is True, then a commit is performed in each
-      separate container, to verify that each tree-conflict indeed blocks
-      a commit.
-
-  The sbox parameter is just the sbox passed to a test function. No need
-  to call sbox.build(), since it is called (once) within this function.
-
-  The "table" greater_scheme models all of the different test cases
-  that should be run using a single repository.
-
-  greater_scheme is a list of DeepTreesTestCase items, which define complete
-  test setups, so that they can be performed as described above.
-  """
-
-  j = os.path.join
-
-  if not sbox.is_built():
-    sbox.build()
-  wc_dir = sbox.wc_dir
-
-  # 1) Create directories.
-  for test_case in greater_scheme:
-    try:
-      base = j(sbox.wc_dir, test_case.name)
-      os.makedirs(base)
-      make_deep_trees(j(base, "incoming"))
-      main.run_svn(None, 'add', base)
-    except:
-      logger.warn("ERROR IN: Tests scheme for merge: "
-          + "while setting up deep trees in '%s'", test_case.name)
-      raise
-
-
-  # 2) Commit pre-initial state (-r2).
-
-  main.run_svn(None, 'commit', '-m', 'pre-initial state', wc_dir)
-
-
-  # 3) Copy "incoming" to "local".
-
-  for test_case in greater_scheme:
-    try:
-      base_url = sbox.repo_url + "/" + test_case.name
-      incoming_url = base_url + "/incoming"
-      local_url = base_url + "/local"
-      main.run_svn(None, 'cp', incoming_url, local_url, '-m',
-                   'copy incoming to local')
-    except:
-      logger.warn("ERROR IN: Tests scheme for merge: "
-          + "while copying deep trees in '%s'", test_case.name)
-      raise
-
-  # 4) Update to load all of the "/local" subdirs into the working copies.
-
-  try:
-    main.run_svn(None, 'up', sbox.wc_dir)
-  except:
-    logger.warn("ERROR IN: Tests scheme for merge: "
-          + "while updating local subdirs")
-    raise
-
-
-  # 5) Perform incoming actions
-
-  for test_case in greater_scheme:
-    try:
-      test_case.incoming_action(j(sbox.wc_dir, test_case.name, "incoming"))
-    except:
-      logger.warn("ERROR IN: Tests scheme for merge: "
-          + "while performing incoming action in '%s'", test_case.name)
-      raise
-
-
-  # 6) or 7) Commit all incoming actions
-
-  if not do_commit_local_changes:
-    try:
-      main.run_svn(None, 'ci', '-m', 'Committing incoming actions',
-                   sbox.wc_dir)
-    except:
-      logger.warn("ERROR IN: Tests scheme for merge: "
-          + "while committing incoming actions")
-      raise
-
-
-  # 7) or 6) Perform all local actions.
-
-  for test_case in greater_scheme:
-    try:
-      test_case.local_action(j(sbox.wc_dir, test_case.name, "local"))
-    except:
-      logger.warn("ERROR IN: Tests scheme for merge: "
-          + "while performing local action in '%s'", test_case.name)
-      raise
-
-
-  # 6) or 7) Commit all incoming actions
-
-  if do_commit_local_changes:
-    try:
-      main.run_svn(None, 'ci', '-m', 'Committing incoming and local actions',
-                   sbox.wc_dir)
-    except:
-      logger.warn("ERROR IN: Tests scheme for merge: "
-          + "while committing incoming and local actions")
-      raise
-
-
-  # 8) Merge all "incoming" subdirs to their respective "local" subdirs.
-  #    This creates conflicts between the local changes in the "local" wc
-  #    subdirs and the incoming states committed in the "incoming" subdirs.
-
-  for test_case in greater_scheme:
-    try:
-      local = j(sbox.wc_dir, test_case.name, "local")
-      incoming = sbox.repo_url + "/" + test_case.name + "/incoming"
-
-      x_out = test_case.expected_output
-      if x_out != None:
-        x_out = x_out.copy()
-        x_out.wc_dir = local
-
-      x_disk = test_case.expected_disk
-
-      x_status = test_case.expected_status
-      if x_status != None:
-        x_status.copy()
-        x_status.wc_dir = local
-
-      x_skip = test_case.expected_skip
-      if x_skip != None:
-        x_skip.copy()
-        x_skip.wc_dir = local
-
-      varargs = (local,)
-      if ignore_ancestry:
-        varargs = varargs + ('--ignore-ancestry',)
-
-      run_and_verify_merge(local, None, None, incoming, None,
-                           x_out, None, None, x_disk, None, x_skip,
-                           test_case.error_re_string,
-                           None, None, None, None,
-                           False, False, *varargs)
-      run_and_verify_unquiet_status(local, x_status)
-    except:
-      logger.warn("ERROR IN: Tests scheme for merge: "
-          + "while verifying in '%s'", test_case.name)
-      raise
-
-
-  # 9) Verify that commit fails.
-
-  if do_commit_conflicts:
-    for test_case in greater_scheme:
-      try:
-        local = j(wc_dir, test_case.name, 'local')
-
-        x_status = test_case.expected_status
-        if x_status != None:
-          x_status.copy()
-          x_status.wc_dir = local
-
-        run_and_verify_commit(local, None, x_status,
-                              test_case.commit_block_string,
-                              local)
-      except:
-        logger.warn("ERROR IN: Tests scheme for merge: "
-            + "while checking commit-blocking in '%s'", test_case.name)
-        raise
+  run_and_verify_svn(verify.AnyOutput, [], 'update', wc_dir)
 
 

--- a/svntest/factory.py
+++ b/svntest/factory.py
@@ -97,7 +97,7 @@
 #
 # YOU ARE CORDIALLY INVITED to add/tweak/change to your needs.
 # If you want to know what's going on, look at the switch()
-# funtion of TestFactory below.
+# function of TestFactory below.
 #
 #
 # DETAILS
@@ -308,8 +308,9 @@ class TestFactory:
     # An optimized list kept up-to-date by variable additions
     self.sorted_vars_by_pathlen = []
 
-    # Wether we ever used the variables 'wc_dir' and 'url' (tiny tweak)
+    # Whether we ever used the variables 'wc_dir' and 'url' (tiny tweak)
     self.used_wc_dir = False
+    self.used_abs_wc_dir = False
     self.used_url = False
 
     # The alternate working copy directories created that need to be
@@ -350,6 +351,8 @@ class TestFactory:
       # main wc_dir and url
       if self.used_wc_dir:
         init += 'wc_dir = sbox.wc_dir\n'
+      if self.used_abs_wc_dir:
+        init += 'abs_wc_dir = os.path.abspath(sbox.wc_dir)\n'
       if self.used_url:
         init += 'url = sbox.repo_url\n'
 
@@ -447,8 +450,13 @@ class TestFactory:
         return self.cmd_svn_checkout(args[2:])
 
       if second in ['propset','pset','ps']:
-        return self.cmd_svn(args[1:], False,
+        multiline_args = [arg.replace(r'\n', '\n') for arg in args[1:]]
+        return self.cmd_svn(multiline_args, False,
           self.keep_args_of, 3)
+
+      if second in ['propget','pget','pg']:
+        return self.cmd_svn(args[1:], False,
+          self.keep_args_of, 2)
 
       if second in ['delete','del','remove', 'rm']:
         return self.cmd_svn(args[1:], False,
@@ -492,7 +500,7 @@ class TestFactory:
       else:
         py = "expected_stdout = verify.UnorderedOutput(" + pylist + ")\n\n"
       py += pychdir
-      py += "actions.run_and_verify_svn2('OUTPUT', expected_stdout, [], 0"
+      py += "actions.run_and_verify_svn2(expected_stdout, [], 0"
     else:
       # write a test that expects failure
       pylist = self.strlist2py(err)
@@ -501,8 +509,7 @@ class TestFactory:
       else:
         py = "expected_stderr = verify.UnorderedOutput(" + pylist + ")\n\n"
       py += pychdir
-      py += ("actions.run_and_verify_svn2('OUTPUT', " +
-             "[], expected_stderr, " + str(code))
+      py += ("actions.run_and_verify_svn2([], expected_stderr, " + str(code))
 
     if len(pyargs) > 0:
       py += ", " + ", ".join(pyargs)
@@ -627,13 +634,13 @@ class TestFactory:
       py += pychdir
       py += ("actions.run_and_verify_update(" + wc.py + ", " +
              "expected_output, expected_disk, expected_status, " +
-             "None, None, None, None, None, False")
+             "[], False")
     else:
       # write a test that expects error
       py = "expected_error = " + self.strlist2py(err) + "\n\n"
       py += pychdir
       py += ("actions.run_and_verify_update(" + wc.py + ", None, None, " +
-             "None, expected_error, None, None, None, None, False")
+             "None, expected_error")
 
     if len(pyargs) > 0:
       py += ', ' + ', '.join(pyargs)
@@ -693,14 +700,14 @@ class TestFactory:
       py += ("actions.run_and_verify_switch(" + wc.py + ", " +
              wc_arg.pyarg + ", " + url_arg.pyarg + ", " +
              "expected_output, expected_disk, expected_status, " +
-             "None, None, None, None, None, False")
+             "[], False")
     else:
       # write a test that expects error
       py = "expected_error = " + self.strlist2py(err) + "\n\n"
       py += pychdir
       py += ("actions.run_and_verify_switch(" + wc.py + ", " +
              wc_arg.pyarg + ", " + url_arg.pyarg + ", " +
-             "None, None, None, expected_error, None, None, None, None, False")
+             "None, None, None, expected_error, False")
 
     if len(pyargs) > 0:
       py += ', ' + ', '.join(pyargs)
@@ -758,7 +765,7 @@ class TestFactory:
 
       py += ("actions.run_and_verify_checkout(" +
              url_arg.pyarg + ", " + wc_arg.pyarg +
-             ", expected_output, expected_disk, None, None, None, None")
+             ", expected_output, expected_disk")
     else:
       # write a test that expects failure
       pylist = self.strlist2py(err)
@@ -767,8 +774,7 @@ class TestFactory:
       else:
         py += "expected_stderr = verify.UnorderedOutput(" + pylist + ")\n\n"
       py += pychdir
-      py += ("actions.run_and_verify_svn2('OUTPUT', " +
-             "[], expected_stderr, " + str(code) +
+      py += ("actions.run_and_verify_svn2([], expected_stderr, " + str(code) +
              ", " + url_arg.pyarg + ", " + wc_arg.pyarg)
 
     # Append the remaining args
@@ -1029,7 +1035,7 @@ class TestFactory:
 
     make_py, prev_status = self.get_prev_status(wc)
 
-    actual_status = svntest.wc.State.from_status(output)
+    actual_status = svntest.wc.State.from_status(output, wc_dir=wc.realpath)
 
     # The tests currently compare SVNTreeNode trees, so let's do that too.
     prev_status_tree = prev_status.old_tree()
@@ -1115,7 +1121,7 @@ class TestFactory:
         if not runpath:
           continue
         strlen = len(runpath)
-        item = [strlen, name, runpath]
+        item = (strlen, name, runpath)
         bisect.insort(lst, item)
 
     return lst
@@ -1128,14 +1134,14 @@ class TestFactory:
     urls = []
     for name in self.vars:
       if name.startswith('url_'):
-        bisect.insort(urls, [name.lower(), name])
+        bisect.insort(urls, (name.lower(), name))
       else:
-        bisect.insort(paths, [name.lower(), name])
+        bisect.insort(paths, (name.lower(), name))
     list = []
     for path in paths:
-      list += [path[1]]
+      list.append(path[1])
     for url in urls:
-      list += [url[1]]
+      list.append(url[1])
     return list
 
 
@@ -1168,8 +1174,20 @@ class TestFactory:
       path = var[2]
       str = replace(str, path, name, quote)
 
-    str = replace(str, self.sbox.wc_dir, 'wc_dir', quote)
-    str = replace(str, self.sbox.repo_url, 'url', quote)
+    str2 = replace(str, os.path.abspath(self.sbox.wc_dir), 'abs_wc_dir', quote)
+    if str != str2:
+      self.used_abs_wc_dir = True
+    str = str2
+
+    str2 = replace(str, self.sbox.wc_dir, 'wc_dir', quote)
+    if str != str2:
+      self.used_wc_dir = True
+    str = str2
+
+    str2 = replace(str, self.sbox.repo_url, 'url', quote)
+    if str != str2:
+      self.used_url = True
+    str = str2
 
     # now remove trailing null-str adds:
     #   '' + url_A_C + ''
@@ -1615,6 +1633,7 @@ class TestFactory:
 
     # special case: if a path is '.', simply use wc_dir.
     if pathelements == ['.']:
+      self.used_wc_dir = True
       return wc.py, wc.realpath
 
     name = "_".join(pathelements)

--- a/svntest/objects.py
+++ b/svntest/objects.py
@@ -127,7 +127,7 @@ def locate_db_dump():
     try:
       if subprocess.Popen([db_dump_name, "-V"]).wait() == 0:
         return db_dump_name
-    except OSError, e:
+    except OSError as e:
       pass
   return 'none'
 
@@ -156,7 +156,7 @@ class SvnRepository:
 
     """Run 'svnadmin dump' on the repository."""
     exit_code, stdout, stderr = \
-      actions.run_and_verify_svnadmin(None, None, None,
+      actions.run_and_verify_svnadmin(None, None,
                                       'dump', self.repo_absdir)
     ldumpfile = local_path(output_dir + "/svnadmin.dump")
     main.file_write(ldumpfile, ''.join(stderr))
@@ -167,7 +167,7 @@ class SvnRepository:
     make, and each directory is a path relative to the repository root,
     neither starting nor ending with a slash."""
     urls = [self.repo_url + '/' + dir for dir in dirs]
-    actions.run_and_verify_svn(None, None, [],
+    actions.run_and_verify_svn(None, [],
                                'mkdir', '-m', 'svn_mkdirs()', '--parents',
                                *urls)
     self.head_rev += 1
@@ -207,7 +207,7 @@ class SvnWC:
 
   def svn_mkdir(self, rpath):
     lpath = local_path(rpath)
-    actions.run_and_verify_svn(None, None, [], 'mkdir', lpath)
+    actions.run_and_verify_svn(None, [], 'mkdir', lpath)
 
     self.state.add({
       rpath : wc.StateItem(status='A ')
@@ -216,7 +216,7 @@ class SvnWC:
 #  def propset(self, pname, pvalue, *rpaths):
 #    "Set property 'pname' to value 'pvalue' on each path in 'rpaths'"
 #    local_paths = tuple([local_path(rpath) for rpath in rpaths])
-#    actions.run_and_verify_svn(None, None, [], 'propset', pname, pvalue,
+#    actions.run_and_verify_svn(None, [], 'propset', pname, pvalue,
 #                               *local_paths)
 
   def svn_set_props(self, rpath, props):
@@ -224,10 +224,10 @@ class SvnWC:
     """
     lpath = local_path(rpath)
     #for prop in path's existing props:
-    #  actions.run_and_verify_svn(None, None, [], 'propdel',
+    #  actions.run_and_verify_svn(None, [], 'propdel',
     #                             prop, lpath)
     for prop in props:
-      actions.run_and_verify_svn(None, None, [], 'propset',
+      actions.run_and_verify_svn(None, [], 'propset',
                                  prop, props[prop], lpath)
     self.state.tweak(rpath, props=props)
 
@@ -240,7 +240,7 @@ class SvnWC:
       content = "This is the file '" + filename + "'.\n" + \
                 "Last changed in '$Revision$'.\n"
     main.file_write(lpath, content)
-    actions.run_and_verify_svn(None, None, [], 'add', lpath)
+    actions.run_and_verify_svn(None, [], 'add', lpath)
 
     self.state.add({
       rpath : wc.StateItem(status='A ')
@@ -257,7 +257,7 @@ class SvnWC:
     lpath = local_path(rpath)
     if content is not None:
       #main.file_append(lpath, "An extra line.\n")
-      #actions.run_and_verify_svn(None, None, [], 'propset',
+      #actions.run_and_verify_svn(None, [], 'propset',
       #                           'newprop', 'v', lpath)
       main.file_write(lpath, content)
       self.state.tweak(rpath, content=content)
@@ -274,7 +274,7 @@ class SvnWC:
     args = [lpath1, lpath2]
     if parents:
       args += ['--parents']
-    actions.run_and_verify_svn(None, None, [], 'copy', *args)
+    actions.run_and_verify_svn(None, [], 'copy', *args)
     self.state.add({
       rpath2: self.state.desc[rpath1]
     })
@@ -292,7 +292,7 @@ class SvnWC:
       args += ['-r', rev]
     if parents:
       args += ['--parents']
-    actions.run_and_verify_svn(None, None, [], 'copy', *args)
+    actions.run_and_verify_svn(None, [], 'copy', *args)
     self.state.add({
       rpath2: self.state.desc[rpath1]
     })
@@ -303,12 +303,12 @@ class SvnWC:
     args = []
     if even_if_modified:
       args += ['--force']
-    actions.run_and_verify_svn(None, None, [], 'delete', lpath, *args)
+    actions.run_and_verify_svn(None, [], 'delete', lpath, *args)
 
   def svn_commit(self, rpath='', log=''):
     "Commit a WC path (recursively). Return the new revision number."
     lpath = local_path(rpath)
-    actions.run_and_verify_svn(None, verify.AnyOutput, [],
+    actions.run_and_verify_svn(verify.AnyOutput, [],
                                'commit', '-m', log, lpath)
     actions.run_and_verify_update(lpath, None, None, None)
     self.repo.head_rev += 1
@@ -332,6 +332,6 @@ class SvnWC:
 #      exp_1 = "--- Merging r.* into '" + target_re + ".*':"
 #      exp_2 = "(A |D |[UG] | [UG]|[UG][UG])   " + target_re + ".*"
 #      exp_out = verify.RegexOutput(exp_1 + "|" + exp_2)
-#    actions.run_and_verify_svn(None, exp_out, [],
+#    actions.run_and_verify_svn(exp_out, [],
 #                               'merge', rev_spec, lsource, ltarget)
 

--- a/svntest/sandbox.py
+++ b/svntest/sandbox.py
@@ -24,12 +24,66 @@
 import os
 import shutil
 import copy
-import urllib
 import logging
+import re
 
 import svntest
 
 logger = logging.getLogger()
+
+
+def make_mirror(sbox, source_prop_encoding=None):
+  """Make a mirror of the repository in SBOX.
+  """
+  # Set up the mirror repository.
+  dest_sbox = sbox.clone_dependent()
+  dest_sbox.build(create_wc=False, empty=True)
+  exit_code, output, errput = svntest.main.run_svnlook("uuid", sbox.repo_dir)
+  svntest.actions.run_and_verify_svnadmin2(None, None, 0,
+                                           'setuuid', dest_sbox.repo_dir,
+                                           output[0][:-1])
+  svntest.actions.enable_revprop_changes(dest_sbox.repo_dir)
+
+  repo_url = sbox.repo_url
+  dest_repo_url = dest_sbox.repo_url
+
+  # Synchronize it.
+  args = (svntest.main.svnrdump_crosscheck_authentication,)
+  if source_prop_encoding:
+    args = args + ("--source-prop-encoding=" + source_prop_encoding,)
+  svntest.actions.run_and_verify_svnsync(svntest.verify.AnyOutput, [],
+                                         "initialize",
+                                         dest_repo_url, repo_url, *args)
+  svntest.actions.run_and_verify_svnsync(None, [],
+                                         "synchronize",
+                                         dest_repo_url, repo_url, *args)
+
+  return dest_sbox
+
+def verify_mirror(repo_url, repo_dir, expected_dumpfile):
+  """Compare the repository content at REPO_URL/REPO_DIR with that in
+     EXPECTED_DUMPFILE (which is a non-delta dump).
+  """
+  # Remove some SVNSync-specific housekeeping properties from the
+  # mirror repository in preparation for the comparison dump.
+  for prop_name in ("svn:sync-from-url", "svn:sync-from-uuid",
+                    "svn:sync-last-merged-rev"):
+    svntest.actions.run_and_verify_svn(
+      None, [], "propdel", "--revprop", "-r", "0",
+      prop_name, repo_url)
+  # Create a dump file from the mirror repository.
+  dumpfile_s_n = svntest.actions.run_and_verify_dump(repo_dir)
+  # Compare the mirror's dumpfile, ignoring any expected differences:
+  # The original dumpfile in some cases lacks 'Text-content-sha1' headers;
+  # the mirror dump always has them -- ### Why?
+  svnsync_headers_always = re.compile("Text-content-sha1: ")
+  dumpfile_a_n_cmp = [l for l in expected_dumpfile
+                      if not svnsync_headers_always.match(l)]
+  dumpfile_s_n_cmp = [l for l in dumpfile_s_n
+                      if not svnsync_headers_always.match(l)]
+  svntest.verify.compare_dump_files(None, None,
+                                    dumpfile_a_n_cmp,
+                                    dumpfile_s_n_cmp)
 
 
 class Sandbox:
@@ -37,6 +91,7 @@ class Sandbox:
   a test to operate within."""
 
   dependents = None
+  tmp_dir = None
 
   def __init__(self, module, idx):
     self.test_paths = []
@@ -45,11 +100,9 @@ class Sandbox:
     # This flag is set to True by build() and returned by is_built()
     self._is_built = False
 
-    # Create an empty directory for temporary files
-    self.tmp_dir = self.add_wc_path('tmp', remove=True)
-    os.mkdir(self.tmp_dir)
+    self.was_cwd = os.getcwd()
 
-  def _set_name(self, name, read_only=False):
+  def _set_name(self, name, read_only=False, empty=False, tree=None):
     """A convenience method for renaming a sandbox, useful when
     working with multiple repositories in the same unit test."""
     if not name is None:
@@ -57,33 +110,29 @@ class Sandbox:
     self.read_only = read_only
     self.wc_dir = os.path.join(svntest.main.general_wc_dir, self.name)
     self.add_test_path(self.wc_dir)
-    if not read_only:
+    if empty or not read_only:  # use a local repo
       self.repo_dir = os.path.join(svntest.main.general_repo_dir, self.name)
       self.repo_url = (svntest.main.options.test_area_url + '/'
-                       + urllib.pathname2url(self.repo_dir))
+                       + svntest.wc.svn_uri_quote(
+                                self.repo_dir.replace(os.path.sep, '/')))
       self.add_test_path(self.repo_dir)
     else:
-      self.repo_dir = svntest.main.pristine_greek_repos_dir
-      self.repo_url = svntest.main.pristine_greek_repos_url
+      if tree == 'greek':
+        self.repo_dir = svntest.main.pristine_greek_repos_dir
+        self.repo_url = svntest.main.pristine_greek_repos_url
+      elif tree == 'trojan':
+        self.repo_dir = svntest.main.pristine_trojan_repos_dir
+        self.repo_url = svntest.main.pristine_trojan_repos_url
+      else:
+        raise ValueError("'tree' must be 'greek' or 'trojan'"
+                         " but was '%s'" % str(tree))
 
-    ### TODO: Move this into to the build() method
-    # For dav tests we need a single authz file which must be present,
-    # so we recreate it each time a sandbox is created with some default
-    # contents, making sure that an empty file is never present
     if self.repo_url.startswith("http"):
-      # this dir doesn't exist out of the box, so we may have to make it
-      if not os.path.exists(svntest.main.work_dir):
-        os.makedirs(svntest.main.work_dir)
       self.authz_file = os.path.join(svntest.main.work_dir, "authz")
-      tmp_authz_file = os.path.join(svntest.main.work_dir, "authz-" + self.name)
-      open(tmp_authz_file, 'w').write("[/]\n* = rw\n")
-      shutil.move(tmp_authz_file, self.authz_file)
-
-    # For svnserve tests we have a per-repository authz file, and it
-    # doesn't need to be there in order for things to work, so we don't
-    # have any default contents.
+      self.groups_file = os.path.join(svntest.main.work_dir, "groups")
     elif self.repo_url.startswith("svn"):
       self.authz_file = os.path.join(self.repo_dir, "conf", "authz")
+      self.groups_file = os.path.join(self.repo_dir, "conf", "groups")
 
   def clone_dependent(self, copy_wc=False):
     """A convenience method for creating a near-duplicate of this
@@ -103,14 +152,37 @@ class Sandbox:
       shutil.copytree(self.wc_dir, clone.wc_dir, symlinks=True)
     return clone
 
-  def build(self, name=None, create_wc=True, read_only=False,
-            minor_version=None):
-    """Make a 'Greek Tree' repo (or refer to the central one if READ_ONLY),
+  def build(self, name=None, create_wc=True, read_only=False, empty=False,
+            minor_version=None, tree='greek'):
+    """Make a 'Greek Tree' or 'Trojan Tree' repo (or refer to the central
+       one if READ_ONLY), or make an empty repo if EMPTY is true,
        and check out a WC from it (unless CREATE_WC is false). Change the
        sandbox's name to NAME. See actions.make_repo_and_wc() for details."""
-    self._set_name(name, read_only)
-    svntest.actions.make_repo_and_wc(self, create_wc, read_only, minor_version)
+    self._set_name(name, read_only, empty, tree)
+    self._ensure_authz()
+    svntest.actions.make_repo_and_wc(self, create_wc, read_only, empty,
+                                     minor_version, tree)
     self._is_built = True
+
+  def _ensure_authz(self):
+    "make sure the repository is accessible"
+
+    def get_content(f):
+      with open(f, 'r') as fp:
+        content = fp.read()
+      return content
+
+    if self.repo_url.startswith("http"):
+      default_authz = "[/]\n* = rw\n"
+
+      if (svntest.main.options.parallel == 0
+          and (not os.path.isfile(self.authz_file)
+               or get_content(self.authz_file) != default_authz)):
+
+        tmp_authz_file = os.path.join(svntest.main.work_dir, "authz-" + self.name)
+        with open(tmp_authz_file, 'w') as f:
+          f.write(default_authz)
+        shutil.move(tmp_authz_file, self.authz_file)
 
   def authz_name(self, repo_dir=None):
     "return this sandbox's name for use in an authz file"
@@ -136,7 +208,8 @@ class Sandbox:
     path = (os.path.join(svntest.main.general_repo_dir, self.name)
             + '.' + suffix)
     url = svntest.main.options.test_area_url + \
-                                        '/' + urllib.pathname2url(path)
+                                        '/' + svntest.wc.svn_uri_quote(
+                                                path.replace(os.path.sep, '/'))
     self.add_test_path(path, remove)
     return path, url
 
@@ -157,9 +230,28 @@ class Sandbox:
     """Get a stable name for a temporary file that will be removed after
        running the test"""
 
+    if not self.tmp_dir:
+      # Create an empty directory for temporary files
+      self.tmp_dir = self.add_wc_path('tmp', remove=True)
+      os.mkdir(self.tmp_dir)
+
     self.tempname_offs = self.tempname_offs + 1
 
     return os.path.join(self.tmp_dir, '%s-%s' % (prefix, self.tempname_offs))
+
+  def create_config_dir(self, config_contents=None, server_contents=None,
+                        ssl_cert=None, ssl_url=None, http_proxy=None,
+                        exclusive_wc_locks=None):
+    """Create a config directory with specified or default files.
+       Return its path.
+    """
+
+    tmp_dir = os.path.abspath(svntest.main.temp_dir)
+    config_dir = os.path.join(tmp_dir, 'config_' + self.name)
+    svntest.main.create_config_dir(config_dir, config_contents, server_contents,
+                                   ssl_cert, ssl_url, http_proxy,
+                                   exclusive_wc_locks)
+    return config_dir
 
   def cleanup_test_paths(self):
     "Clean up detritus from this sandbox, and any dependents."
@@ -181,13 +273,23 @@ class Sandbox:
        of this sbox, or relative to OS-style path WC_DIR if supplied."""
     if wc_dir is None:
       wc_dir = self.wc_dir
-    return os.path.join(wc_dir, svntest.wc.to_ospath(relpath))
+
+    if relpath == '':
+      return wc_dir
+    else:
+      return os.path.join(wc_dir, svntest.wc.to_ospath(relpath))
 
   def ospaths(self, relpaths, wc_dir=None):
     """Return a list of RELPATHS but with each path converted to an OS-style
        path relative to the WC dir of this sbox, or relative to OS-style
        path WC_DIR if supplied."""
     return [self.ospath(rp, wc_dir) for rp in relpaths]
+
+  def path(self, relpath, wc_dir=None):
+    """Return RELPATH converted to an path relative to the WC dir
+       of this sbox, or relative to WC_DIR if supplied, but always
+       using '/' as directory separator."""
+    return self.ospath(relpath, wc_dir=wc_dir).replace(os.path.sep, '/')
 
   def redirected_root_url(self, temporary=False):
     """If TEMPORARY is set, return the URL which should be configured
@@ -201,6 +303,12 @@ class Sandbox:
     return '%s/REDIRECT-%s-%s' % (parts[0],
                                   temporary and 'TEMP' or 'PERM',
                                   parts[1])
+
+  def file_protocol_repo_url(self):
+    """get a file:// url pointing to the repository"""
+    return svntest.main.file_scheme_prefix + \
+           svntest.wc.svn_uri_quote(
+                os.path.abspath(self.repo_dir).replace(os.path.sep, '/'))
 
   def simple_update(self, target=None, revision='HEAD'):
     """Update the WC or TARGET.
@@ -231,8 +339,8 @@ class Sandbox:
       target = self.ospath(target)
     if message is None:
       message = svntest.main.make_log_msg()
-    svntest.main.run_svn(False, 'commit', '-m', message,
-                         target)
+    svntest.actions.run_and_verify_commit(self.wc_dir, None, None, [],
+                                          '-m', message, target)
 
   def simple_rm(self, *targets):
     """Schedule TARGETS for deletion.
@@ -307,6 +415,27 @@ class Sandbox:
         raise Exception("Unexpected line '" + line + "' in proplist output" + str(out))
     return props
 
+  def simple_symlink(self, dest, target):
+    """Create a symlink TARGET pointing to DEST"""
+    if svntest.main.is_posix_os():
+      os.symlink(dest, self.ospath(target))
+    else:
+      svntest.main.file_write(self.ospath(target), "link %s" % dest)
+
+  def simple_add_symlink(self, dest, target, add=True):
+    """Create a symlink TARGET pointing to DEST and add it to subversion"""
+    self.simple_symlink(dest, target)
+    self.simple_add(target)
+    if not svntest.main.is_posix_os():      # '*' is evaluated on Windows
+      self.simple_propset('svn:special', 'X', target)
+
+  def simple_add_text(self, text, *targets):
+    """Create files containing TEXT as TARGETS"""
+    assert len(targets) > 0
+    for target in targets:
+       svntest.main.file_write(self.ospath(target), text, mode='wb')
+    self.simple_add(*targets)
+
   def simple_copy(self, source, dest):
     """Copy SOURCE to DEST in the WC.
        SOURCE and DEST are relpaths relative to the WC."""
@@ -332,8 +461,144 @@ class Sandbox:
   def simple_append(self, dest, contents, truncate=False):
     """Append CONTENTS to file DEST, optionally truncating it first.
        DEST is a relpath relative to the WC."""
-    open(self.ospath(dest), truncate and 'w' or 'a').write(contents)
+    svntest.main.file_write(self.ospath(dest), contents,
+                            truncate and 'wb' or 'ab')
 
+  def simple_lock(self, *targets):
+    """Lock TARGETS in the WC.
+       TARGETS are relpaths relative to the WC."""
+    assert len(targets) > 0
+    targets = self.ospaths(targets)
+    svntest.main.run_svn(False, 'lock', *targets)
+
+  def youngest(self):
+    _, output, _ = svntest.actions.run_and_verify_svnlook(
+                     svntest.verify.AnyOutput, [],
+                     'youngest', self.repo_dir)
+    youngest = int(output[0])
+    return youngest
+
+  def verify_repo(self):
+    """
+    """
+    svnrdump_headers_missing = re.compile(
+        "Text-content-sha1: .*|Text-copy-source-md5: .*|"
+        "Text-copy-source-sha1: .*|Text-delta-base-sha1: .*"
+    )
+    svnrdump_headers_always = re.compile(
+        "Prop-delta: .*"
+    )
+
+    dumpfile_a_n = svntest.actions.run_and_verify_dump(self.repo_dir,
+                                                       deltas=False)
+    dumpfile_a_d = svntest.actions.run_and_verify_dump(self.repo_dir,
+                                                       deltas=True)
+    dumpfile_r_d = svntest.actions.run_and_verify_svnrdump(
+      None, svntest.verify.AnyOutput, [], 0, 'dump', '-q', self.repo_url,
+      svntest.main.svnrdump_crosscheck_authentication)
+
+    # Compare the two deltas dumpfiles, ignoring expected differences
+    dumpfile_a_d_cmp = [l for l in dumpfile_a_d
+                       if not svnrdump_headers_missing.match(l)
+                                and not svnrdump_headers_always.match(l)]
+    dumpfile_r_d_cmp = [l for l in dumpfile_r_d
+                       if not svnrdump_headers_always.match(l)]
+    # Ignore differences in number of blank lines between node records,
+    # as svnrdump puts 3 whereas svnadmin puts 2 after a replace-with-copy.
+    svntest.verify.compare_dump_files('svnadmin dump, tweaked',
+                                      'svnrdump dump, tweaked',
+                                      dumpfile_a_d_cmp,
+                                      dumpfile_r_d_cmp,
+                                      ignore_number_of_blank_lines=True)
+
+    # Try loading the dump files.
+    # For extra points, load each with the other tool:
+    #   svnadmin dump | svnrdump load
+    #   svnrdump dump | svnadmin load
+    repo_dir_a_n, repo_url_a_n = self.add_repo_path('load_a_n')
+    svntest.main.create_repos(repo_dir_a_n)
+    svntest.actions.enable_revprop_changes(repo_dir_a_n)
+    svntest.actions.run_and_verify_svnrdump(
+      dumpfile_a_n, svntest.verify.AnyOutput, [], 0, 'load', repo_url_a_n,
+      svntest.main.svnrdump_crosscheck_authentication)
+
+    repo_dir_a_d, repo_url_a_d = self.add_repo_path('load_a_d')
+    svntest.main.create_repos(repo_dir_a_d)
+    svntest.actions.enable_revprop_changes(repo_dir_a_d)
+    svntest.actions.run_and_verify_svnrdump(
+      dumpfile_a_d, svntest.verify.AnyOutput, [], 0, 'load', repo_url_a_d,
+      svntest.main.svnrdump_crosscheck_authentication)
+
+    repo_dir_r_d, repo_url_r_d = self.add_repo_path('load_r_d')
+    svntest.main.create_repos(repo_dir_r_d)
+    svntest.actions.run_and_verify_load(repo_dir_r_d, dumpfile_r_d)
+
+    # Dump the loaded repositories in the same way; expect exact equality
+    reloaded_dumpfile_a_n = svntest.actions.run_and_verify_dump(repo_dir_a_n)
+    reloaded_dumpfile_a_d = svntest.actions.run_and_verify_dump(repo_dir_a_d)
+    reloaded_dumpfile_r_d = svntest.actions.run_and_verify_dump(repo_dir_r_d)
+    svntest.verify.compare_dump_files('svnadmin dump no delta, loaded, dumped',
+                                      'svnadmin dump --deltas, loaded, dumped',
+                                      reloaded_dumpfile_a_n,
+                                      reloaded_dumpfile_a_d,
+                                      ignore_uuid=True)
+    svntest.verify.compare_dump_files('svnadmin dump, loaded, dumped',
+                                      'svnrdump dump, loaded, dumped',
+                                      reloaded_dumpfile_a_d,
+                                      reloaded_dumpfile_r_d,
+                                      ignore_uuid=True)
+
+    # Run each dump through svndumpfilter and check for no further change.
+    for dumpfile, dumpfile_desc in [(dumpfile_a_n, 'svnadmin dump'),
+                                    (dumpfile_a_d, 'svnadmin dump --deltas'),
+                                    (dumpfile_r_d, 'svnrdump dump'),
+                                    ]:
+      ### No buffer size seems to work for update_tests-2. So skip that test?
+      ### (Its dumpfile size is ~360 KB non-delta, ~180 KB delta.)
+      if len(''.join(dumpfile)) > 100000:
+        continue
+
+      exit_code, dumpfile2, errput = svntest.main.run_command_stdin(
+        svntest.main.svndumpfilter_binary, None, -1, True,
+        dumpfile, '--quiet', 'include', '/')
+      assert not exit_code and not errput
+      # Ignore empty prop sections in the input file during comparison, as
+      # svndumpfilter strips them.
+      # Ignore differences in number of blank lines between node records,
+      # as svndumpfilter puts 3 instead of 2 after an add or delete record.
+      svntest.verify.compare_dump_files(dumpfile_desc,
+                                        'after svndumpfilter include /',
+                                        dumpfile, dumpfile2,
+                                        expect_content_length_always=True,
+                                        ignore_empty_prop_sections=True,
+                                        ignore_number_of_blank_lines=True)
+
+    # Run the repository through 'svnsync' and check that this does not
+    # change the repository content. (Don't bother if it's already been
+    # created by svnsync.)
+    if "svn:sync-from-url\n" not in dumpfile_a_n:
+      dest_sbox = make_mirror(self)
+      verify_mirror(dest_sbox.repo_url, dest_sbox.repo_dir, dumpfile_a_n)
+
+  def verify(self, skip_cross_check=False):
+    """Do additional testing that should hold for any sandbox, such as
+       verifying that the repository can be dumped.
+    """
+    if (not skip_cross_check
+        and svntest.main.tests_verify_dump_load_cross_check()):
+      if self.is_built() and not self.read_only:
+        # verify that we can in fact dump the repo
+        # (except for the few tests that deliberately corrupt the repo)
+        os.chdir(self.was_cwd)
+        if os.path.exists(self.repo_dir):
+          logger.info("VERIFY: running dump/load cross-check")
+          self.verify_repo()
+      else:
+        logger.info("VERIFY: WARNING: skipping dump/load cross-check:"
+                    " is-built=%s, read-only=%s"
+                    % (self.is_built() and "true" or "false",
+                       self.read_only and "true" or "false"))
+    pass
 
 def is_url(target):
   return (target.startswith('^/')
@@ -361,7 +626,7 @@ def _cleanup_test_path(path, retrying=False):
     logger.info("CLEANUP: %s", path)
 
   try:
-    svntest.main.safe_rmtree(path)
+    svntest.main.safe_rmtree(path, retrying)
   except:
     logger.info("WARNING: cleanup failed, will try again later")
     _deferred_test_paths.append(path)

--- a/svntest/testcase.py
+++ b/svntest/testcase.py
@@ -28,7 +28,8 @@ import os, types, sys
 import svntest
 
 # if somebody does a "from testcase import *", they only get these names
-__all__ = ['_XFail', '_Wimp', '_Skip', '_SkipUnless']
+__all__ = ['_XFail', '_Wimp', '_Skip', '_SkipUnless',
+           '_SkipDumpLoadCrossCheck']
 
 RESULT_OK = 'ok'
 RESULT_FAIL = 'fail'
@@ -135,14 +136,14 @@ class FunctionTestCase(TestCase):
   is derived from the file name in which FUNC was defined)
   """
 
-  def __init__(self, func, issues=None):
+  def __init__(self, func, issues=None, skip_cross_check=False):
     # it better be a function that accepts an sbox parameter and has a
     # docstring on it.
     assert isinstance(func, types.FunctionType)
 
-    name = func.func_name
+    name = func.__name__
 
-    assert func.func_code.co_argcount == 1, \
+    assert func.__code__.co_argcount == 1, \
         '%s must take an sbox argument' % name
 
     doc = func.__doc__.strip()
@@ -161,19 +162,22 @@ class FunctionTestCase(TestCase):
 
     TestCase.__init__(self, doc=doc, issues=issues)
     self.func = func
+    self.skip_cross_check = skip_cross_check
 
   def get_function_name(self):
-    return self.func.func_name
+    return self.func.__name__
 
   def get_sandbox_name(self):
     """Base the sandbox's name on the name of the file in which the
     function was defined."""
 
-    filename = self.func.func_code.co_filename
+    filename = self.func.__code__.co_filename
     return os.path.splitext(os.path.basename(filename))[0]
 
   def run(self, sandbox):
-    return self.func(sandbox)
+    result = self.func(sandbox)
+    sandbox.verify(skip_cross_check = self.skip_cross_check)
+    return result
 
 
 class _XFail(TestCase):
@@ -218,8 +222,8 @@ class _Wimp(_XFail):
     RESULT_SKIP: (2, TextColors.success('SKIP: '), True),
     }
 
-  def __init__(self, wip, test_case, cond_func=lambda: True):
-    _XFail.__init__(self, test_case, cond_func, wip)
+  def __init__(self, wip, test_case, cond_func=lambda: True, issues=None):
+    _XFail.__init__(self, test_case, cond_func, wip, issues)
 
 
 class _Skip(TestCase):
@@ -261,11 +265,22 @@ class _SkipUnless(_Skip):
     _Skip.__init__(self, test_case, lambda c=cond_func: not c())
 
 
-def create_test_case(func, issues=None):
+class _SkipDumpLoadCrossCheck(TestCase):
+  """A test that will skip the post-test dump/load cross-check."""
+
+  def __init__(self, test_case, cond_func=lambda: True, wip=None,
+               issues=None):
+    TestCase.__init__(self,
+                      create_test_case(test_case, skip_cross_check=True),
+                      cond_func, wip=wip, issues=issues)
+
+
+def create_test_case(func, issues=None, skip_cross_check=False):
   if isinstance(func, TestCase):
     return func
   else:
-    return FunctionTestCase(func, issues=issues)
+    return FunctionTestCase(func, issues=issues,
+                            skip_cross_check=skip_cross_check)
 
 
 # Various decorators to make declaring tests as such simpler
@@ -321,6 +336,16 @@ def Issues_deco(*issues):
       return create_test_case(func, issues=issues)
 
   return _second
+
+def SkipDumpLoadCrossCheck_deco(cond_func = lambda: True):
+  def _second(func):
+    if isinstance(func, TestCase):
+      return _SkipDumpLoadCrossCheck(func, cond_func, issues=func.issues)
+    else:
+      return _SkipDumpLoadCrossCheck(func, cond_func)
+
+  return _second
+
 
 # Create a singular alias, for linguistic correctness
 Issue_deco = Issues_deco

--- a/svntest/tree.py
+++ b/svntest/tree.py
@@ -253,6 +253,10 @@ class SVNTreeNode:
     # remove the subtree path, skip this node if necessary.
     if path.startswith(subtree):
       path = path[len(subtree):]
+    elif path + os.sep == subtree:
+      # Many callers set subtree to 'some-path' + os.sep. Don't skip the
+      # root node in that case.
+      path = ''
     else:
       return 0
 
@@ -263,34 +267,14 @@ class SVNTreeNode:
     line += "%-20s: Item(" % ("'%s'" % path.replace(os.sep, '/'))
     comma = False
 
-    mime_type = self.props.get("svn:mime-type")
-    if not mime_type or mime_type.startswith("text/"):
-      if self.contents is not None:
-        # Escape some characters for nicer script and readability.
-        # (This is error output. I guess speed is no consideration here.)
-        line += "contents=\"%s\"" % (self.contents
-                                     .replace('\n','\\n')
-                                     .replace('"','\\"')
-                                     .replace('\r','\\r')
-                                     .replace('\t','\\t'))
-        comma = True
-    else:
-      line += 'content is binary data'
+    if self.contents is not None:
+      line += "contents=" + repr(self.contents)
       comma = True
 
     if self.props:
       if comma:
         line += ", "
-      line += "props={"
-      comma = False
-
-      for name in self.props:
-        if comma:
-          line += ", "
-        line += "'%s':'%s'" % (name, self.props[name])
-        comma = True
-
-      line += "}"
+      line += ("props=%s" % self.props)
       comma = True
 
     for name in self.atts:
@@ -504,6 +488,7 @@ def create_from_path(path, contents=None, props={}, atts={}):
 
 
 eol_re = re.compile(r'(\r\n|\r)')
+eol_re_binary = re.compile(br'(\r\n|\r)')
 
 # helper for build_tree_from_wc()
 def get_props(paths):
@@ -549,7 +534,10 @@ def get_props(paths):
       # contains a CR character XML-encoded as '&#13;'.  The XML
       # parser converts it back into a CR character.  So again convert
       # all end-of-line variants into a single LF:
-      value = eol_re.sub('\n', value)
+      if isinstance(value, str):
+        value = eol_re.sub('\n', value)
+      else:
+        value = eol_re_binary.sub(b'\n', value)
       file_props[name] = value
     files[filename] = file_props
 
@@ -565,7 +553,9 @@ def get_text(path):
   if not os.path.isfile(path):
     return None
 
-  return open(path, 'r').read()
+  with open(path, 'r') as fp:
+    content = fp.read()
+  return content
 
 
 def get_child(node, name):
@@ -605,6 +595,11 @@ def detect_conflict_files(node, extra_files):
     logger.warn(msg)
     logger.warn(str(node))
     raise SVNTreeUnequal(msg)
+
+def detect_conflict_files_done(extra_files):
+   """Done handler for detect_conflict_files"""
+   if len(extra_files):
+    raise SVNTreeError("Not all extra reject files have been accounted for")
 
 ###########################################################################
 ###########################################################################
@@ -715,7 +710,7 @@ def _dump_tree(n,indent="",stream=sys.stdout):
   the SVNTreeNode N. Prefix each line with the string INDENT."""
 
   # Code partially stolen from Dave Beazley
-  tmp_children = sorted(n.children or [])
+  tmp_children = sorted(n.children or [], key=SVNTreeNode.get_printable_path)
 
   if n.name == root_node_name:
     stream.write("%s%s\n" % (indent, "ROOT"))
@@ -862,10 +857,16 @@ def build_tree_from_diff_summarize(lines):
 #   process for every file and dir in the working copy!
 
 
-def build_tree_from_wc(wc_path, load_props=0, ignore_svn=1):
+def build_tree_from_wc(wc_path, load_props=0, ignore_svn=1, keep_eol_style=False):
     """Takes WC_PATH as the path to a working copy.  Walks the tree below
     that path, and creates the tree based on the actual found
     files.  If IGNORE_SVN is true, then exclude SVN admin dirs from the tree.
-    If LOAD_PROPS is true, the props will be added to the tree."""
+    If LOAD_PROPS is true, the props will be added to the tree.
 
-    return svntest.wc.State.from_wc(wc_path, load_props, ignore_svn).old_tree()
+    If KEEP_EOL_STYLE is set, don't let Python normalize the EOL when
+    reading working copy contents as text files.  It has no effect on
+    binary files.
+    """
+
+    return svntest.wc.State.from_wc(wc_path, load_props, ignore_svn,
+                                    keep_eol_style).old_tree()

--- a/svntest/verify.py
+++ b/svntest/verify.py
@@ -96,129 +96,75 @@ def createExpectedOutput(expected, output_type, match_all=True):
     raise SVNIncorrectDatatype("Unexpected type for '%s' data" % output_type)
   return expected
 
-class ExpectedOutput:
-  """Contains expected output, and performs comparisons."""
+class ExpectedOutput(object):
+  """Matches an ordered list of lines.
 
-  is_regex = False
-  is_unordered = False
+     If MATCH_ALL is True, the expected lines must match all the actual
+     lines, one-to-one, in the same order.  If MATCH_ALL is False, the
+     expected lines must match a subset of the actual lines, one-to-one,
+     in the same order, ignoring any other actual lines among the
+     matching ones.
+  """
 
-  def __init__(self, output, match_all=True):
-    """Initialize the expected output to OUTPUT which is a string, or a list
-    of strings, or None meaning an empty list. If MATCH_ALL is True, the
-    expected strings will be matched with the actual strings, one-to-one, in
-    the same order. If False, they will be matched with a subset of the
-    actual strings, one-to-one, in the same order, ignoring any other actual
-    strings among the matching ones."""
-    self.output = output
+  def __init__(self, expected, match_all=True):
+    """Initialize the expected output to EXPECTED which is a string, or
+       a list of strings.
+
+       See also: svntest.verify.createExpectedOutput().
+    """
+    assert expected is not None
+    self.expected = expected
     self.match_all = match_all
 
   def __str__(self):
-    return str(self.output)
+    return str(self.expected)
 
   def __cmp__(self, other):
-    raise Exception('badness')
+    raise TypeError("ExpectedOutput does not implement direct comparison; "
+                    "see the 'matches()' method")
 
-  def matches(self, other, except_re=None):
-    """Return whether SELF.output matches OTHER (which may be a list
-    of newline-terminated lines, or a single string).  Either value
-    may be None."""
-    if self.output is None:
-      expected = []
-    else:
-      expected = self.output
-    if other is None:
-      actual = []
-    else:
-      actual = other
-
-    if not isinstance(actual, list):
-      actual = [actual]
+  def matches(self, actual):
+    """Return whether SELF matches ACTUAL (which may be a list
+       of newline-terminated lines, or a single string).
+    """
+    assert actual is not None
+    expected = self.expected
     if not isinstance(expected, list):
       expected = [expected]
+    if not isinstance(actual, list):
+      actual = [actual]
 
-    if except_re:
-      return self.matches_except(expected, actual, except_re)
-    else:
-      return self.is_equivalent_list(expected, actual)
-
-  def matches_except(self, expected, actual, except_re):
-    "Return whether EXPECTED and ACTUAL match except for except_re."
-    if not self.is_regex:
-      i_expected = 0
-      i_actual = 0
-      while i_expected < len(expected) and i_actual < len(actual):
-        if re.match(except_re, actual[i_actual]):
-          i_actual += 1
-        elif re.match(except_re, expected[i_expected]):
-          i_expected += 1
-        elif expected[i_expected] == actual[i_actual]:
-          i_expected += 1
-          i_actual += 1
-        else:
-          return False
-      if i_expected == len(expected) and i_actual == len(actual):
-            return True
-      return False
-    else:
-      raise Exception("is_regex and except_re are mutually exclusive")
-
-  def is_equivalent_list(self, expected, actual):
-    "Return whether EXPECTED and ACTUAL are equivalent."
-    if not self.is_regex:
-      if self.match_all:
-        # The EXPECTED lines must match the ACTUAL lines, one-to-one, in
-        # the same order.
-        return expected == actual
-
-      # The EXPECTED lines must match a subset of the ACTUAL lines,
-      # one-to-one, in the same order, with zero or more other ACTUAL
-      # lines interspersed among the matching ACTUAL lines.
-      i_expected = 0
-      for actual_line in actual:
-        if expected[i_expected] == actual_line:
-          i_expected += 1
-          if i_expected == len(expected):
-            return True
-      return False
-
-    expected_re = expected[0]
-    # If we want to check that every line matches the regexp
-    # assume they all match and look for any that don't.  If
-    # only one line matching the regexp is enough, assume none
-    # match and look for even one that does.
     if self.match_all:
-      all_lines_match_re = True
-    else:
-      all_lines_match_re = False
+      return expected == actual
 
-    # If a regex was provided assume that we actually require
-    # some output. Fail if we don't have any.
-    if len(actual) == 0:
-      return False
-
+    i_expected = 0
     for actual_line in actual:
-      if self.match_all:
-        if not re.match(expected_re, actual_line):
-          return False
-      else:
-        # As soon an actual_line matches something, then we're good.
-        if re.match(expected_re, actual_line):
+      if expected[i_expected] == actual_line:
+        i_expected += 1
+        if i_expected == len(expected):
           return True
-
-    return all_lines_match_re
+    return False
 
   def display_differences(self, message, label, actual):
-    """Delegate to the display_lines() routine with the appropriate
-    args.  MESSAGE is ignored if None."""
-    display_lines(message, label, self.output, actual,
-                  self.is_regex, self.is_unordered)
+    """Show the differences between the expected and ACTUAL lines. Print
+       MESSAGE unless it is None, the expected lines, the ACTUAL lines,
+       and a diff, all labeled with LABEL.
+    """
+    e_label = label + ' (match_all=%s)' % (self.match_all,)
+    display_lines(message, self.expected, actual, e_label, label)
+    display_lines_diff(self.expected, actual, e_label, label)
 
 
 class AnyOutput(ExpectedOutput):
-  def __init__(self):
-    ExpectedOutput.__init__(self, None, False)
+  """Matches any non-empty output.
+  """
 
-  def is_equivalent_list(self, ignored, actual):
+  def __init__(self):
+    ExpectedOutput.__init__(self, [], False)
+
+  def matches(self, actual):
+    assert actual is not None
+
     if len(actual) == 0:
       # No actual output. No match.
       return False
@@ -236,61 +182,245 @@ class AnyOutput(ExpectedOutput):
       logger.warn(message)
 
 
+def re_fullmatch(pattern, string, flags=0):
+  """If the whole STRING matches the regular expression PATTERN,
+     return a corresponding match object.
+     Based on re.fullmatch() in Python 3.4.
+  """
+  if pattern.endswith('$'):
+    return re.match(pattern, string, flags)
+
+  return re.match(pattern + '$', string, flags)
+
+def regex_fullmatch(rx, string):
+  """If the whole STRING matches the compiled regular expression RX,
+     return a corresponding match object.
+     Based on regex.fullmatch() in Python 3.4.
+  """
+  if rx.pattern.endswith('$'):
+    return rx.match(string)
+
+  return re_fullmatch(rx.pattern, string, rx.flags)
+
 class RegexOutput(ExpectedOutput):
-  is_regex = True
+  """Matches a single regular expression.
+
+     If MATCH_ALL is true, every actual line must match the RE.  If
+     MATCH_ALL is false, at least one actual line must match the RE.  In
+     any case, there must be at least one line of actual output.
+
+     The RE must match a prefix of the actual line, in contrast to the
+     RegexListOutput and UnorderedRegexListOutput classes which match
+     whole lines.
+  """
+
+  def __init__(self, expected, match_all=True):
+    "EXPECTED is a regular expression string."
+    assert isinstance(expected, str) or isinstance(expected, bytes)
+    ExpectedOutput.__init__(self, expected, match_all)
+    self.expected_re = re.compile(expected)
+
+  def matches(self, actual):
+    assert actual is not None
+
+    if not isinstance(actual, list):
+      actual = [actual]
+
+    # If a regex was provided assume that we require some actual output.
+    # Fail if we don't have any.
+    if len(actual) == 0:
+      return False
+
+    if self.match_all:
+      return all(self.expected_re.match(line) for line in actual)
+    else:
+      return any(self.expected_re.match(line) for line in actual)
+
+  def display_differences(self, message, label, actual):
+    e_label = label + ' (regexp, match_all=%s)' % (self.match_all,)
+    display_lines(message, self.expected, actual, e_label, label)
+
+  def insert(self, index, line):
+    self.expected.insert(index, line)
+    self.expected_re = re.compile(self.expected)
+
+class RegexListOutput(ExpectedOutput):
+  """Matches an ordered list of regular expressions.
+
+     If MATCH_ALL is True, the expressions must match all the actual
+     lines, one-to-one, in the same order.  If MATCH_ALL is False, the
+     expressions must match a subset of the actual lines, one-to-one, in
+     the same order, ignoring any other actual lines among the matching
+     ones.
+
+     In any case, there must be at least one line of actual output.
+
+     The REs must match whole actual lines, in contrast to the RegexOutput
+     class which matches a prefix of the actual line.
+  """
+
+  def __init__(self, expected, match_all=True):
+    "EXPECTED is a list of regular expression strings."
+    assert isinstance(expected, list)
+    ExpectedOutput.__init__(self, expected, match_all)
+    self.expected_res = [re.compile(e) for e in expected]
+
+  def matches(self, actual):
+    assert actual is not None
+    if not isinstance(actual, list):
+      actual = [actual]
+
+    if self.match_all:
+      return (len(self.expected_res) == len(actual) and
+              all(regex_fullmatch(e, a) for e, a in zip(self.expected_res, actual)))
+
+    i_expected = 0
+    for actual_line in actual:
+      if regex_fullmatch(self.expected_res[i_expected], actual_line):
+        i_expected += 1
+        if i_expected == len(self.expected_res):
+          return True
+    return False
+
+  def display_differences(self, message, label, actual):
+    e_label = label + ' (regexp, match_all=%s)' % (self.match_all,)
+    display_lines(message, self.expected, actual, e_label, label)
+
+    assert actual is not None
+    if not isinstance(actual, list):
+      actual = [actual]
+
+    if self.match_all:
+      logger.warn('DIFF ' + label + ':')
+      if len(self.expected) != len(actual):
+        logger.warn('# Expected %d lines; actual %d lines' %
+                    (len(self.expected), len(actual)))
+      for e, a in map(None, self.expected_res, actual):
+        if e is not None and a is not None and regex_fullmatch(e, a):
+          logger.warn("|  " + a.rstrip())
+        else:
+          if e is not None:
+            logger.warn("| -" + repr(e.pattern))
+          if a is not None:
+            logger.warn("| +" + repr(a))
+
+  def insert(self, index, line):
+    self.expected.insert(index, line)
+    self.expected_res = [re.compile(e) for e in self.expected]
 
 
 class UnorderedOutput(ExpectedOutput):
-  """Marks unordered output, and performs comparisons."""
+  """Matches an unordered list of lines.
 
-  is_unordered = True
+     The expected lines must match all the actual lines, one-to-one, in
+     any order.
+  """
 
-  def __cmp__(self, other):
-    raise Exception('badness')
+  def __init__(self, expected):
+    assert isinstance(expected, list)
+    ExpectedOutput.__init__(self, expected)
 
-  def matches_except(self, expected, actual, except_re):
-    assert type(actual) == type([]) # ### if this trips: fix it!
-    return self.is_equivalent_list([l for l in expected if not except_re.match(l)],
-                                   [l for l in actual if not except_re.match(l)])
+  def matches(self, actual):
+    if not isinstance(actual, list):
+      actual = [actual]
 
-  def is_equivalent_list(self, expected, actual):
-    "Disregard the order of ACTUAL lines during comparison."
+    return sorted(self.expected) == sorted(actual)
 
-    e_set = set(expected)
-    a_set = set(actual)
+  def display_differences(self, message, label, actual):
+    e_label = label + ' (unordered)'
+    display_lines(message, self.expected, actual, e_label, label)
+    display_lines_diff(sorted(self.expected), sorted(actual), e_label, label)
 
-    if self.match_all:
-      if len(e_set) != len(a_set):
-        return False
-      if self.is_regex:
-        for expect_re in e_set:
-          for actual_line in a_set:
-            if re.match(expect_re, actual_line):
-              a_set.remove(actual_line)
-              break
-          else:
-            # One of the regexes was not found
-            return False
-        return True
 
-      # All expected lines must be in the output.
-      return e_set == a_set
+class UnorderedRegexListOutput(ExpectedOutput):
+  """Matches an unordered list of regular expressions.
 
-    if self.is_regex:
-      # If any of the expected regexes are in the output, then we match.
-      for expect_re in e_set:
-        for actual_line in a_set:
-          if re.match(expect_re, actual_line):
-            return True
+     The expressions must match all the actual lines, one-to-one, in any
+     order.
+
+     Note: This can give a false negative result (no match) when there is
+     an actual line that matches multiple expressions and a different
+     actual line that matches some but not all of those same
+     expressions.  The implementation matches each expression in turn to
+     the first unmatched actual line that it can match, and does not try
+     all the permutations when there are multiple possible matches.
+
+     The REs must match whole actual lines, in contrast to the RegexOutput
+     class which matches a prefix of the actual line.
+  """
+
+  def __init__(self, expected):
+    assert isinstance(expected, list)
+    ExpectedOutput.__init__(self, expected)
+
+  def matches(self, actual):
+    assert actual is not None
+    if not isinstance(actual, list):
+      actual = [actual]
+    else:
+      # copy the list so we can remove elements without affecting caller
+      actual = actual[:]
+
+    if len(self.expected) != len(actual):
       return False
+    for e in self.expected:
+      expect_re = re.compile(e)
+      for actual_line in actual:
+        if regex_fullmatch(expect_re, actual_line):
+          actual.remove(actual_line)
+          break
+      else:
+        # One of the regexes was not found
+        return False
+    return True
 
-    # If any of the expected lines are in the output, then we match.
-    return len(e_set.intersection(a_set)) > 0
+  def display_differences(self, message, label, actual):
+    e_label = label + ' (regexp) (unordered)'
+    display_lines(message, self.expected, actual, e_label, label)
 
+    assert actual is not None
+    if not isinstance(actual, list):
+      actual = [actual]
+    else:
+      # copy the list so we can remove elements without affecting caller
+      actual = actual[:]
 
-class UnorderedRegexOutput(UnorderedOutput, RegexOutput):
-  is_regex = True
-  is_unordered = True
+    logger.warn('DIFF ' + label + ':')
+    if len(self.expected) != len(actual):
+      logger.warn('# Expected %d lines; actual %d lines' %
+                  (len(self.expected), len(actual)))
+    for e in self.expected:
+      expect_re = re.compile(e)
+      for actual_line in actual:
+        if regex_fullmatch(expect_re, actual_line):
+          actual.remove(actual_line)
+          break
+      else:
+        logger.warn("| -" + expect_re.pattern.rstrip())
+    for a in actual:
+      logger.warn("| +" + a.rstrip())
+
+class AlternateOutput(ExpectedOutput):
+  """Matches any one of a list of ExpectedOutput instances.
+  """
+
+  def __init__(self, expected, match_all=True):
+    "EXPECTED is a list of ExpectedOutput instances."
+    assert isinstance(expected, list) and expected != []
+    assert all(isinstance(e, ExpectedOutput) for e in expected)
+    ExpectedOutput.__init__(self, expected)
+
+  def matches(self, actual):
+    assert actual is not None
+    for e in self.expected:
+      if e.matches(actual):
+        return True
+    return False
+
+  def display_differences(self, message, label, actual):
+    # For now, just display differences against the first alternative.
+    e = self.expected[0]
+    e.display_differences(message, label, actual)
 
 
 ######################################################################
@@ -308,63 +438,68 @@ def display_trees(message, label, expected, actual):
     svntest.tree.dump_tree(actual)
 
 
-def display_lines(message, label, expected, actual, expected_is_regexp=None,
-                  expected_is_unordered=None):
+def display_lines_diff(expected, actual, expected_label, actual_label):
+  """Print a unified diff between EXPECTED (labeled with EXPECTED_LABEL)
+     and ACTUAL (labeled with ACTUAL_LABEL).
+     Each of EXPECTED and ACTUAL is a string or a list of strings.
+  """
+  if not isinstance(expected, list):
+    expected = [expected]
+  if not isinstance(actual, list):
+    actual = [actual]
+  logger.warn('DIFF ' + expected_label + ':')
+  for x in unified_diff(expected, actual,
+                        fromfile='EXPECTED ' + expected_label,
+                        tofile='ACTUAL ' + actual_label):
+    logger.warn('| ' + x.rstrip())
+
+def display_lines(message, expected, actual,
+                  expected_label, actual_label=None):
   """Print MESSAGE, unless it is None, then print EXPECTED (labeled
-  with LABEL) followed by ACTUAL (also labeled with LABEL).
-  Both EXPECTED and ACTUAL may be strings or lists of strings."""
+     with EXPECTED_LABEL) followed by ACTUAL (labeled with ACTUAL_LABEL).
+     Each of EXPECTED and ACTUAL is a string or a list of strings.
+  """
   if message is not None:
     logger.warn(message)
+
+  if type(expected) is str:
+    expected = [expected]
+  if type(actual) is str:
+    actual = [actual]
+  if actual_label is None:
+    actual_label = expected_label
   if expected is not None:
-    output = 'EXPECTED %s' % label
-    if expected_is_regexp:
-      output += ' (regexp)'
-      expected = [expected + '\n']
-    if expected_is_unordered:
-      output += ' (unordered)'
-    output += ':'
-    logger.warn(output)
+    logger.warn('EXPECTED %s:', expected_label)
     for x in expected:
-      sys.stdout.write(x)
+      logger.warn('| ' + x.rstrip())
   if actual is not None:
-    logger.warn('ACTUAL %s:', label)
+    logger.warn('ACTUAL %s:', actual_label)
     for x in actual:
-      sys.stdout.write(x)
-
-  # Additionally print unified diff
-  if not expected_is_regexp:
-    logger.warn('DIFF ' + ' '.join(output.split(' ')[1:]))
-
-    if type(expected) is str:
-      expected = [expected]
-
-    if type(actual) is str:
-      actual = [actual]
-
-    for x in unified_diff(expected, actual,
-                          fromfile="EXPECTED %s" % label,
-                          tofile="ACTUAL %s" % label):
-      sys.stdout.write(x)
+      logger.warn('| ' + x.rstrip())
 
 def compare_and_display_lines(message, label, expected, actual,
-                              raisable=None, except_re=None):
+                              raisable=None):
   """Compare two sets of output lines, and print them if they differ,
   preceded by MESSAGE iff not None.  EXPECTED may be an instance of
-  ExpectedOutput (and if not, it is wrapped as such).  RAISABLE is an
+  ExpectedOutput (and if not, it is wrapped as such).  ACTUAL may be a
+  list of newline-terminated lines, or a single string.  RAISABLE is an
   exception class, an instance of which is thrown if ACTUAL doesn't
   match EXPECTED."""
   if raisable is None:
     raisable = svntest.main.SVNLineUnequal
   ### It'd be nicer to use createExpectedOutput() here, but its
   ### semantics don't match all current consumers of this function.
+  assert expected is not None
+  assert actual is not None
   if not isinstance(expected, ExpectedOutput):
     expected = ExpectedOutput(expected)
 
-  if isinstance(actual, str):
-    actual = [actual]
-  actual = [line for line in actual if not line.startswith('DBG:')]
+  actual = svntest.main.ensure_list(actual)
+  if len(actual) > 0:
+    is_binary = not isinstance(actual[0], str)
+    actual = svntest.main.filter_dbg(actual, is_binary)
 
-  if not expected.matches(actual, except_re):
+  if not expected.matches(actual):
     expected.display_differences(message, label, actual)
     raise raisable
 
@@ -402,32 +537,34 @@ def verify_exit_code(message, actual, expected,
   not None) and raise an exception."""
 
   if expected != actual:
-    display_lines(message, "Exit Code",
-                  str(expected) + '\n', str(actual) + '\n')
+    display_lines(message, str(expected), str(actual), "Exit Code")
     raise raisable
 
 # A simple dump file parser.  While sufficient for the current
 # testsuite it doesn't cope with all valid dump files.
 class DumpParser:
-  def __init__(self, lines):
+  def __init__(self, lines, ignore_sha1=False):
     self.current = 0
     self.lines = lines
     self.parsed = {}
+    self.ignore_sha1 = ignore_sha1
 
   def parse_line(self, regex, required=True):
     m = re.match(regex, self.lines[self.current])
     if not m:
       if required:
         raise SVNDumpParseError("expected '%s' at line %d\n%s"
+                                "\nPrevious lines:\n%s"
                                 % (regex, self.current,
-                                   self.lines[self.current]))
+                                   self.lines[self.current],
+                                   ''.join(self.lines[max(0,self.current - 10):self.current])))
       else:
         return None
     self.current += 1
     return m.group(1)
 
   def parse_blank(self, required=True):
-    if self.lines[self.current] != '\n':  # Works on Windows
+    if self.lines[self.current] != b'\n':  # Works on Windows
       if required:
         raise SVNDumpParseError("expected blank at line %d\n%s"
                                 % (self.current, self.lines[self.current]))
@@ -436,70 +573,128 @@ class DumpParser:
     self.current += 1
     return True
 
+  def parse_header(self, header):
+    regex = b'([^:]*): (.*)$'
+    m = re.match(regex, self.lines[self.current])
+    if not m:
+      raise SVNDumpParseError("expected a header at line %d, but found:\n%s"
+                              % (self.current, self.lines[self.current]))
+    self.current += 1
+    return m.groups()
+
+  def parse_headers(self):
+    headers = []
+    while self.lines[self.current] != b'\n':
+      key, val = self.parse_header(self)
+      headers.append((key, val))
+    return headers
+
+
+  def parse_boolean(self, header, required):
+    return self.parse_line(header + b': (false|true)$', required)
+
   def parse_format(self):
-    return self.parse_line('SVN-fs-dump-format-version: ([0-9]+)$')
+    return self.parse_line(b'SVN-fs-dump-format-version: ([0-9]+)$')
 
   def parse_uuid(self):
-    return self.parse_line('UUID: ([0-9a-z-]+)$')
+    return self.parse_line(b'UUID: ([0-9a-z-]+)$')
 
   def parse_revision(self):
-    return self.parse_line('Revision-number: ([0-9]+)$')
+    return self.parse_line(b'Revision-number: ([0-9]+)$')
+
+  def parse_prop_delta(self):
+    return self.parse_line(b'Prop-delta: (false|true)$', required=False)
 
   def parse_prop_length(self, required=True):
-    return self.parse_line('Prop-content-length: ([0-9]+)$', required)
+    return self.parse_line(b'Prop-content-length: ([0-9]+)$', required)
 
   def parse_content_length(self, required=True):
-    return self.parse_line('Content-length: ([0-9]+)$', required)
+    return self.parse_line(b'Content-length: ([0-9]+)$', required)
 
   def parse_path(self):
-    path = self.parse_line('Node-path: (.+)$', required=False)
-    if not path and self.lines[self.current] == 'Node-path: \n':
-      self.current += 1
-      path = ''
+    path = self.parse_line(b'Node-path: (.*)$', required=False)
     return path
 
   def parse_kind(self):
-    return self.parse_line('Node-kind: (.+)$', required=False)
+    return self.parse_line(b'Node-kind: (.+)$', required=False)
 
   def parse_action(self):
-    return self.parse_line('Node-action: ([0-9a-z-]+)$')
+    return self.parse_line(b'Node-action: ([0-9a-z-]+)$')
 
   def parse_copyfrom_rev(self):
-    return self.parse_line('Node-copyfrom-rev: ([0-9]+)$', required=False)
+    return self.parse_line(b'Node-copyfrom-rev: ([0-9]+)$', required=False)
 
   def parse_copyfrom_path(self):
-    path = self.parse_line('Node-copyfrom-path: (.+)$', required=False)
+    path = self.parse_line(b'Node-copyfrom-path: (.+)$', required=False)
     if not path and self.lines[self.current] == 'Node-copyfrom-path: \n':
       self.current += 1
       path = ''
     return path
 
   def parse_copy_md5(self):
-    return self.parse_line('Text-copy-source-md5: ([0-9a-z]+)$', required=False)
+    return self.parse_line(b'Text-copy-source-md5: ([0-9a-z]+)$', required=False)
 
   def parse_copy_sha1(self):
-    return self.parse_line('Text-copy-source-sha1: ([0-9a-z]+)$', required=False)
+    return self.parse_line(b'Text-copy-source-sha1: ([0-9a-z]+)$', required=False)
 
   def parse_text_md5(self):
-    return self.parse_line('Text-content-md5: ([0-9a-z]+)$', required=False)
+    return self.parse_line(b'Text-content-md5: ([0-9a-z]+)$', required=False)
 
   def parse_text_sha1(self):
-    return self.parse_line('Text-content-sha1: ([0-9a-z]+)$', required=False)
+    return self.parse_line(b'Text-content-sha1: ([0-9a-z]+)$', required=False)
+
+  def parse_text_delta(self):
+    return self.parse_line(b'Text-delta: (false|true)$', required=False)
+
+  def parse_text_delta_base_md5(self):
+    return self.parse_line(b'Text-delta-base-md5: ([0-9a-f]+)$', required=False)
+
+  def parse_text_delta_base_sha1(self):
+    return self.parse_line(b'Text-delta-base-sha1: ([0-9a-f]+)$', required=False)
 
   def parse_text_length(self):
-    return self.parse_line('Text-content-length: ([0-9]+)$', required=False)
+    return self.parse_line(b'Text-content-length: ([0-9]+)$', required=False)
 
-  # One day we may need to parse individual property name/values into a map
   def get_props(self):
     props = []
-    while not re.match('PROPS-END$', self.lines[self.current]):
+    while not re.match(b'PROPS-END$', self.lines[self.current]):
       props.append(self.lines[self.current])
       self.current += 1
     self.current += 1
-    return props
+
+    # Split into key/value pairs to do an unordered comparison.
+    # This parses the serialized hash under the assumption that it is valid.
+    prophash = {}
+    curprop = [0]
+    while curprop[0] < len(props):
+      def read_key_or_value(curprop):
+        # klen / vlen
+        klen = int(props[curprop[0]].split()[1])
+        curprop[0] += 1
+
+        # key / value
+        key = b''
+        while len(key) != klen + 1:
+          key += props[curprop[0]]
+          curprop[0] += 1
+        key = key[:-1]
+
+        return key
+
+      if props[curprop[0]].startswith(b'K'):
+        key = read_key_or_value(curprop)
+        value = read_key_or_value(curprop)
+      elif props[curprop[0]].startswith(b'D'):
+        key = read_key_or_value(curprop)
+        value = None
+      else:
+        raise
+      prophash[key] = value
+
+    return prophash
 
   def get_content(self, length):
-    content = ''
+    content = b''
     while len(content) < length:
       content += self.lines[self.current]
       self.current += 1
@@ -512,17 +707,46 @@ class DumpParser:
 
   def parse_one_node(self):
     node = {}
+
+    # optional 'kind' and required 'action' must be next
     node['kind'] = self.parse_kind()
     action = self.parse_action()
-    node['copyfrom_rev'] = self.parse_copyfrom_rev()
-    node['copyfrom_path'] = self.parse_copyfrom_path()
-    node['copy_md5'] = self.parse_copy_md5()
-    node['copy_sha1'] = self.parse_copy_sha1()
-    node['prop_length'] = self.parse_prop_length(required=False)
-    node['text_length'] = self.parse_text_length()
-    node['text_md5'] = self.parse_text_md5()
-    node['text_sha1'] = self.parse_text_sha1()
-    node['content_length'] = self.parse_content_length(required=False)
+
+    # read any remaining headers
+    headers_list = self.parse_headers()
+    headers = dict(headers_list)
+
+    # Content-length must be last, if present
+    if b'Content-length' in headers and headers_list[-1][0] != b'Content-length':
+      raise SVNDumpParseError("'Content-length' header is not last, "
+                              "in header block ending at line %d"
+                              % (self.current,))
+
+    # parse the remaining optional headers and store in specific keys in NODE
+    for key, header, regex in [
+        ('copyfrom_rev',    b'Node-copyfrom-rev',    b'([0-9]+)$'),
+        ('copyfrom_path',   b'Node-copyfrom-path',   b'(.*)$'),
+        ('copy_md5',        b'Text-copy-source-md5', b'([0-9a-z]+)$'),
+        ('copy_sha1',       b'Text-copy-source-sha1',b'([0-9a-z]+)$'),
+        ('prop_length',     b'Prop-content-length',  b'([0-9]+)$'),
+        ('text_length',     b'Text-content-length',  b'([0-9]+)$'),
+        ('text_md5',        b'Text-content-md5',     b'([0-9a-z]+)$'),
+        ('text_sha1',       b'Text-content-sha1',    b'([0-9a-z]+)$'),
+        ('content_length',  b'Content-length',       b'([0-9]+)$'),
+        ]:
+      if not header in headers:
+        node[key] = None
+        continue
+      if self.ignore_sha1 and (key in ['copy_sha1', 'text_sha1']):
+        node[key] = None
+        continue
+      m = re.match(regex, headers[header])
+      if not m:
+        raise SVNDumpParseError("expected '%s' at line %d\n%s"
+                                % (regex, self.current,
+                                   self.lines[self.current]))
+      node[key] = m.group(1)
+
     self.parse_blank()
     if node['prop_length']:
       node['props'] = self.get_props()
@@ -544,7 +768,7 @@ class DumpParser:
       if self.current >= len(self.lines):
         break
       path = self.parse_path()
-      if not path and not path is '':
+      if path is None:
         break
       if not nodes.get(path):
         nodes[path] = {}
@@ -582,16 +806,234 @@ class DumpParser:
     self.parse_all_revisions()
     return self.parsed
 
-def compare_dump_files(message, label, expected, actual):
+def compare_dump_files(label_expected, label_actual,
+                       expected, actual,
+                       ignore_uuid=False,
+                       expect_content_length_always=False,
+                       ignore_empty_prop_sections=False,
+                       ignore_number_of_blank_lines=False):
   """Parse two dump files EXPECTED and ACTUAL, both of which are lists
   of lines as returned by run_and_verify_dump, and check that the same
   revisions, nodes, properties, etc. are present in both dumps.
   """
-
-  parsed_expected = DumpParser(expected).parse()
+  parsed_expected = DumpParser(expected, not svntest.main.fs_has_sha1()).parse()
   parsed_actual = DumpParser(actual).parse()
 
+  if ignore_uuid:
+    parsed_expected['uuid'] = '<ignored>'
+    parsed_actual['uuid'] = '<ignored>'
+
+  for parsed in [parsed_expected, parsed_actual]:
+    for rev_name, rev_record in parsed.items():
+      #print "Found %s" % (rev_name,)
+      if b'nodes' in rev_record:
+        #print "Found %s.%s" % (rev_name, 'nodes')
+        for path_name, path_record in rev_record['nodes'].items():
+          #print "Found %s.%s.%s" % (rev_name, 'nodes', path_name)
+          for action_name, action_record in path_record.items():
+            #print "Found %s.%s.%s.%s" % (rev_name, 'nodes', path_name, action_name)
+
+            if expect_content_length_always:
+              if action_record.get('content_length') == None:
+                #print 'Adding: %s.%s.%s.%s.%s' % (rev_name, 'nodes', path_name, action_name, 'content_length=0')
+                action_record['content_length'] = '0'
+            if ignore_empty_prop_sections:
+              if action_record.get('prop_length') == '10':
+                #print 'Removing: %s.%s.%s.%s.%s' % (rev_name, 'nodes', path_name, action_name, 'prop_length')
+                action_record['prop_length'] = None
+                del action_record['props']
+                old_content_length = int(action_record['content_length'])
+                action_record['content_length'] = str(old_content_length - 10)
+            if ignore_number_of_blank_lines:
+              action_record['blanks'] = 0
+
   if parsed_expected != parsed_actual:
-    raise svntest.Failure('\n' + '\n'.join(ndiff(
+    print('DIFF of raw dumpfiles (including expected differences)')
+    print('--- ' + (label_expected or 'expected'))
+    print('+++ ' + (label_actual or 'actual'))
+    print(''.join(ndiff(expected, actual)))
+    raise svntest.Failure('DIFF of parsed dumpfiles (ignoring expected differences)\n'
+                          + '\n'.join(ndiff(
           pprint.pformat(parsed_expected).splitlines(),
           pprint.pformat(parsed_actual).splitlines())))
+
+##########################################################################################
+## diff verifications
+def is_absolute_url(target):
+  return (target.startswith('file://')
+          or target.startswith('http://')
+          or target.startswith('https://')
+          or target.startswith('svn://')
+          or target.startswith('svn+ssh://'))
+
+def make_diff_header(path, old_tag, new_tag, src_label=None, dst_label=None):
+  """Generate the expected diff header for file PATH, with its old and new
+  versions described in parentheses by OLD_TAG and NEW_TAG. SRC_LABEL and
+  DST_LABEL are paths or urls that are added to the diff labels if we're
+  diffing against the repository or diffing two arbitrary paths.
+  Return the header as an array of newline-terminated strings."""
+  if src_label:
+    src_label = src_label.replace('\\', '/')
+    if not is_absolute_url(src_label):
+      src_label = '.../' + src_label
+    src_label = '\t(' + src_label + ')'
+  else:
+    src_label = ''
+  if dst_label:
+    dst_label = dst_label.replace('\\', '/')
+    if not is_absolute_url(dst_label):
+      dst_label = '.../' + dst_label
+    dst_label = '\t(' + dst_label + ')'
+  else:
+    dst_label = ''
+  path_as_shown = path.replace('\\', '/')
+  return [
+    "Index: " + path_as_shown + "\n",
+    "===================================================================\n",
+    "--- " + path_as_shown + src_label + "\t(" + old_tag + ")\n",
+    "+++ " + path_as_shown + dst_label + "\t(" + new_tag + ")\n",
+    ]
+
+def make_no_diff_deleted_header(path, old_tag, new_tag):
+  """Generate the expected diff header for a deleted file PATH when in
+  'no-diff-deleted' mode. (In that mode, no further details appear after the
+  header.) Return the header as an array of newline-terminated strings."""
+  path_as_shown = path.replace('\\', '/')
+  return [
+    "Index: " + path_as_shown + " (deleted)\n",
+    "===================================================================\n",
+    ]
+
+def make_git_diff_header(target_path, repos_relpath,
+                         old_tag, new_tag, add=False, src_label=None,
+                         dst_label=None, delete=False, text_changes=True,
+                         cp=False, mv=False, copyfrom_path=None,
+                         copyfrom_rev=None):
+  """ Generate the expected 'git diff' header for file TARGET_PATH.
+  REPOS_RELPATH is the location of the path relative to the repository root.
+  The old and new versions ("revision X", or "working copy") must be
+  specified in OLD_TAG and NEW_TAG.
+  SRC_LABEL and DST_LABEL are paths or urls that are added to the diff
+  labels if we're diffing against the repository. ADD, DELETE, CP and MV
+  denotes the operations performed on the file. COPYFROM_PATH is the source
+  of a copy or move.  Return the header as an array of newline-terminated
+  strings."""
+
+  path_as_shown = target_path.replace('\\', '/')
+  if src_label:
+    src_label = src_label.replace('\\', '/')
+    src_label = '\t(.../' + src_label + ')'
+  else:
+    src_label = ''
+  if dst_label:
+    dst_label = dst_label.replace('\\', '/')
+    dst_label = '\t(.../' + dst_label + ')'
+  else:
+    dst_label = ''
+
+  output = [
+    "Index: " + path_as_shown + "\n",
+    "===================================================================\n"
+  ]
+  if add:
+    output.extend([
+      "diff --git a/" + repos_relpath + " b/" + repos_relpath + "\n",
+      "new file mode 100644\n",
+    ])
+    if text_changes:
+      output.extend([
+        "--- a/" + repos_relpath + src_label + "\t(" + old_tag + ")\n",
+        "+++ b/" + repos_relpath + dst_label + "\t(" + new_tag + ")\n"
+      ])
+  elif delete:
+    output.extend([
+      "diff --git a/" + repos_relpath + " b/" + repos_relpath + "\n",
+      "deleted file mode 100644\n",
+    ])
+    if text_changes:
+      output.extend([
+        "--- a/" + repos_relpath + src_label + "\t(" + old_tag + ")\n",
+        "+++ b/" + repos_relpath + dst_label + "\t(" + new_tag + ")\n"
+      ])
+  elif cp:
+    if copyfrom_rev:
+      copyfrom_rev = '@' + copyfrom_rev
+    else:
+      copyfrom_rev = ''
+    output.extend([
+      "diff --git a/" + copyfrom_path + " b/" + repos_relpath + "\n",
+      "copy from " + copyfrom_path + copyfrom_rev + "\n",
+      "copy to " + repos_relpath + "\n",
+    ])
+    if text_changes:
+      output.extend([
+        "--- a/" + copyfrom_path + src_label + "\t(" + old_tag + ")\n",
+        "+++ b/" + repos_relpath + "\t(" + new_tag + ")\n"
+      ])
+  elif mv:
+    output.extend([
+      "diff --git a/" + copyfrom_path + " b/" + path_as_shown + "\n",
+      "rename from " + copyfrom_path + "\n",
+      "rename to " + repos_relpath + "\n",
+    ])
+    if text_changes:
+      output.extend([
+        "--- a/" + copyfrom_path + src_label + "\t(" + old_tag + ")\n",
+        "+++ b/" + repos_relpath + "\t(" + new_tag + ")\n"
+      ])
+  else:
+    output.extend([
+      "diff --git a/" + repos_relpath + " b/" + repos_relpath + "\n",
+      "--- a/" + repos_relpath + src_label + "\t(" + old_tag + ")\n",
+      "+++ b/" + repos_relpath + dst_label + "\t(" + new_tag + ")\n",
+    ])
+  return output
+
+def make_diff_prop_header(path):
+  """Return a property diff sub-header, as a list of newline-terminated
+     strings."""
+  return [
+    "\n",
+    "Property changes on: " + path.replace('\\', '/') + "\n",
+    "___________________________________________________________________\n"
+  ]
+
+def make_diff_prop_val(plus_minus, pval):
+  "Return diff for prop value PVAL, with leading PLUS_MINUS (+ or -)."
+  if len(pval) > 0 and pval[-1] != '\n':
+    return [plus_minus + pval + "\n","\\ No newline at end of property\n"]
+  return [plus_minus + pval]
+
+def make_diff_prop_deleted(pname, pval):
+  """Return a property diff for deletion of property PNAME, old value PVAL.
+     PVAL is a single string with no embedded newlines.  Return the result
+     as a list of newline-terminated strings."""
+  return [
+    "Deleted: " + pname + "\n",
+    "## -1 +0,0 ##\n"
+  ] + make_diff_prop_val("-", pval)
+
+def make_diff_prop_added(pname, pval):
+  """Return a property diff for addition of property PNAME, new value PVAL.
+     PVAL is a single string with no embedded newlines.  Return the result
+     as a list of newline-terminated strings."""
+  return [
+    "Added: " + pname + "\n",
+    "## -0,0 +1 ##\n",
+  ] + make_diff_prop_val("+", pval)
+
+def make_diff_prop_modified(pname, pval1, pval2):
+  """Return a property diff for modification of property PNAME, old value
+     PVAL1, new value PVAL2.
+
+     PVAL is a single string with no embedded newlines.  A newline at the
+     end is significant: without it, we add an extra line saying '\ No
+     newline at end of property'.
+
+     Return the result as a list of newline-terminated strings.
+  """
+  return [
+    "Modified: " + pname + "\n",
+    "## -1 +1 ##\n",
+  ] + make_diff_prop_val("-", pval1) + make_diff_prop_val("+", pval2)
+

--- a/svntest/wc.py
+++ b/svntest/wc.py
@@ -26,16 +26,18 @@
 import os
 import sys
 import re
-import urllib
 import logging
 import pprint
+import io
 
 if sys.version_info[0] >= 3:
   # Python >=3.0
   from io import StringIO
+  from urllib.parse import quote as urllib_quote
 else:
   # Python <3.0
   from cStringIO import StringIO
+  from urllib import quote as urllib_quote
 
 import svntest
 
@@ -94,7 +96,13 @@ _re_parse_status = re.compile('^([?!MACDRUGXI_~ ][MACDRUG_ ])'
                               '((?P<wc_rev>\d+|-|\?) +(\d|-|\?)+ +(\S+) +)?'
                               '(?P<path>.+)$')
 
-_re_parse_skipped = re.compile("^Skipped[^']* '(.+)'( --.*)?\n")
+_re_parse_status_ex = re.compile('^      ('
+               '(  \> moved (from (?P<moved_from>.+)|to (?P<moved_to>.*)))'
+              '|(  \> swapped places with (?P<swapped_with>.+).*)'
+              '|(\>   (?P<tc>.+))'
+  ')$')
+
+_re_parse_skipped = re.compile("^(Skipped[^']*) '(.+)'( --.*)?\n")
 
 _re_parse_summarize = re.compile("^([MAD ][M ])      (.+)\n")
 
@@ -110,6 +118,15 @@ _re_parse_co_restored = re.compile('^(Restored)\s+\'(.+)\'')
 _re_parse_commit_ext = re.compile('^(([A-Za-z]+( [a-z]+)*)) \'(.+)\'( --.*)?')
 _re_parse_commit = re.compile('^(\w+(  \(bin\))?)\s+(.+)')
 
+#rN: eids 0 15 branches 4
+_re_parse_eid_header = re.compile('^r(-1|[0-9]+): eids ([0-9]+) ([0-9]+) '
+                                  'branches ([0-9]+)$')
+# B0.2 root-eid 3
+_re_parse_eid_branch = re.compile('^(B[0-9.]+) root-eid ([0-9]+) num-eids ([0-9]+)( from [^ ]*)?$')
+_re_parse_eid_merge_history = re.compile('merge-history: merge-ancestors ([0-9]+)')
+# e4: normal 6 C
+_re_parse_eid_ele = re.compile('^e([0-9]+): (none|normal|subbranch) '
+                               '(-1|[0-9]+) (.*)$')
 
 class State:
   """Describes an existing or expected state of a working copy.
@@ -135,14 +152,17 @@ class State:
 
     self.desc.update(more_desc)
 
-  def add_state(self, parent, state):
+  def add_state(self, parent, state, strict=False):
     "Import state items from a State object, reparent the items to PARENT."
     assert isinstance(state, State)
 
-    if parent and parent[-1] != '/':
-      parent += '/'
     for path, item in state.desc.items():
-      path = parent + path
+      if strict:
+        path = parent + path
+      elif path == '':
+        path = parent
+      else:
+        path = parent + '/' + path
       self.desc[path] = item
 
   def remove(self, *paths):
@@ -154,7 +174,7 @@ class State:
     "Remove PATHS recursively from the state (the paths must exist)."
     for subtree_path in paths:
       subtree_path = to_relpath(subtree_path)
-      for path, item in self.desc.items():
+      for path, item in svntest.main.ensure_list(self.desc.items()):
         if path == subtree_path or path[:len(subtree_path) + 1] == subtree_path + '/':
           del self.desc[path]
 
@@ -183,7 +203,7 @@ class State:
       for path in args:
         try:
           path_ref = self.desc[to_relpath(path)]
-        except KeyError, e:
+        except KeyError as e:
           e.args = ["Path '%s' not present in WC state descriptor" % path]
           raise
         path_ref.tweak(**kw)
@@ -196,6 +216,30 @@ class State:
     for path, item in self.desc.items():
       if list(filter(path, item)):
         item.tweak(**kw)
+
+  def rename(self, moves):
+    """Change the path of some items.
+
+    MOVES is a dictionary mapping source path to destination
+    path. Children move with moved parents.  All subtrees are moved in
+    reverse depth order to temporary storage before being moved in
+    depth order to the final location.  This allows nested moves.
+
+    """
+    temp = {}
+    for src, dst in sorted(moves.items(), key=lambda pair: pair[0])[::-1]:
+      temp[src] = {}
+      for path, item in svntest.main.ensure_list(self.desc.items()):
+        if path == src or path[:len(src) + 1] == src + '/':
+          temp[src][path] = item;
+          del self.desc[path]
+    for src, dst in sorted(moves.items(), key=lambda pair: pair[1]):
+      for path, item in temp[src].items():
+        if path == src:
+          new_path = dst
+        else:
+          new_path = dst + path[len(src):]
+        self.desc[new_path] = item
 
   def subtree(self, subtree_path):
     """Return a State object which is a deep copy of the sub-tree
@@ -231,7 +275,7 @@ class State:
           os.makedirs(dirpath)
 
         # write out the file contents now
-        open(fullpath, 'wb').write(item.contents)
+        svntest.main.file_write(fullpath, item.contents, 'wb')
 
   def normalize(self):
     """Return a "normalized" version of self.
@@ -256,6 +300,20 @@ class State:
 
     desc = dict([(repos_join(base, path), item)
                  for path, item in self.desc.items()])
+
+    for path, item in desc.copy().items():
+      if item.moved_from or item.moved_to:
+        i = item.copy()
+
+        if i.moved_from:
+          i.moved_from = to_relpath(os.path.normpath(
+                                        repos_join(base, i.moved_from)))
+        if i.moved_to:
+          i.moved_to = to_relpath(os.path.normpath(
+                                        repos_join(base, i.moved_to)))
+
+        desc[path] = i
+
     return State('', desc)
 
   def compare(self, other):
@@ -324,11 +382,24 @@ class State:
 
   def tweak_for_entries_compare(self):
     for path, item in self.desc.copy().items():
-      if item.status:
+      if item.status and path in self.desc:
         # If this is an unversioned tree-conflict, remove it.
         # These are only in their parents' THIS_DIR, they don't have entries.
-        if item.status[0] in '!?' and item.treeconflict == 'C':
+        if item.status[0] in '!?' and item.treeconflict == 'C' and \
+                                      item.entry_status is None:
           del self.desc[path]
+        # Normal externals are not stored in the parent wc, drop the root
+        # and everything in these working copies
+        elif item.status == 'X ' or item.prev_status == 'X ':
+          del self.desc[path]
+          for p, i in self.desc.copy().items():
+            if p.startswith(path + '/'):
+              del self.desc[p]
+        elif item.entry_kind == 'file':
+          # A file has no descendants in svn_wc_entry_t
+          for p, i in self.desc.copy().items():
+            if p.startswith(path + '/'):
+              del self.desc[p]
         else:
           # when reading the entry structures, we don't examine for text or
           # property mods, so clear those flags. we also do not examine the
@@ -347,6 +418,9 @@ class State:
           if item.entry_status is not None:
             item.status = item.entry_status
             item.entry_status = None
+          if item.entry_copied is not None:
+            item.copied = item.entry_copied
+            item.entry_copied = None
       if item.writelocked:
         # we don't contact the repository, so our only information is what
         # is in the working copy. 'K' means we have one and it matches the
@@ -362,6 +436,11 @@ class State:
           item.writelocked = 'K'
         elif item.writelocked == 'O':
           item.writelocked = None
+      item.moved_from = None
+      item.moved_to = None
+      if path == '':
+        item.switched = None
+      item.treeconflict = None
 
   def old_tree(self):
     "Return an old-style tree (for compatibility purposes)."
@@ -397,7 +476,7 @@ class State:
     return not self.__eq__(other)
 
   @classmethod
-  def from_status(cls, lines):
+  def from_status(cls, lines, wc_dir=None):
     """Create a State object from 'svn status' output."""
 
     def not_space(value):
@@ -405,21 +484,54 @@ class State:
         return value
       return None
 
+    def parse_move(path, wc_dir):
+      if path.startswith('../'):
+        # ../ style paths are relative from the status root
+        return to_relpath(os.path.normpath(repos_join(wc_dir, path)))
+      else:
+        # Other paths are just relative from cwd
+        return to_relpath(path)
+
+    if not wc_dir:
+      wc_dir = ''
+
     desc = { }
+    last = None
     for line in lines:
       if line.startswith('DBG:'):
         continue
 
-      # Quit when we hit an externals status announcement.
-      ### someday we can fix the externals tests to expect the additional
-      ### flood of externals status data.
-      if line.startswith('Performing'):
-        break
-
       match = _re_parse_status.search(line)
       if not match or match.group(10) == '-':
+
+        ex_match = _re_parse_status_ex.search(line)
+
+        if ex_match:
+          if ex_match.group('moved_from'):
+            path = to_relpath(ex_match.group('moved_from'))
+            last.tweak(moved_from = parse_move(path, wc_dir))
+          elif ex_match.group('moved_to'):
+            path = to_relpath(ex_match.group('moved_to'))
+            last.tweak(moved_to = parse_move(path, wc_dir))
+          elif ex_match.group('swapped_with'):
+            path = to_relpath(ex_match.group('swapped_with'))
+            last.tweak(moved_to = parse_move(path, wc_dir))
+            last.tweak(moved_from = parse_move(path, wc_dir))
+
+          # Parse TC description?
+
         # ignore non-matching lines, or items that only exist on repos
         continue
+
+      prev_status = None
+      prev_treeconflict = None
+
+      path = to_relpath(match.group('path'))
+      if path == '.':
+        path = ''
+      if path in desc:
+        prev_status = desc[path].status
+        prev_treeconflict = desc[path].treeconflict
 
       item = StateItem(status=match.group(1),
                        locked=not_space(match.group(2)),
@@ -428,8 +540,11 @@ class State:
                        writelocked=not_space(match.group(5)),
                        treeconflict=not_space(match.group(6)),
                        wc_rev=not_space(match.group('wc_rev')),
+                       prev_status=prev_status,
+                       prev_treeconflict =prev_treeconflict
                        )
-      desc[to_relpath(match.group('path'))] = item
+      desc[path] = item
+      last = item
 
     return cls('', desc)
 
@@ -444,7 +559,8 @@ class State:
 
       match = _re_parse_skipped.search(line)
       if match:
-        desc[to_relpath(match.group(1))] = StateItem()
+        desc[to_relpath(match.group(2))] =  StateItem(
+          verb=(match.group(1).strip(':')))
 
     return cls('', desc)
 
@@ -483,12 +599,38 @@ class State:
           treeconflict = match.group(3)
         else:
           treeconflict = None
-        desc[to_relpath(match.group(4))] = StateItem(status=match.group(1),
-                                                     treeconflict=treeconflict)
+        path = to_relpath(match.group(4))
+        prev_status = None
+        prev_verb = None
+        prev_treeconflict = None
+
+        if path in desc:
+          prev_status = desc[path].status
+          prev_verb = desc[path].verb
+          prev_treeconflict = desc[path].treeconflict
+
+        desc[path] = StateItem(status=match.group(1),
+                               treeconflict=treeconflict,
+                               prev_status=prev_status,
+                               prev_verb=prev_verb,
+                               prev_treeconflict=prev_treeconflict)
       else:
         match = re_extra.search(line)
         if match:
-          desc[to_relpath(match.group(2))] = StateItem(verb=match.group(1))
+          path = to_relpath(match.group(2))
+          prev_status = None
+          prev_verb = None
+          prev_treeconflict = None
+
+          if path in desc:
+            prev_status = desc[path].status
+            prev_verb = desc[path].verb
+            prev_treeconflict = desc[path].treeconflict
+
+          desc[path] = StateItem(verb=match.group(1),
+                                 prev_status=prev_status,
+                                 prev_verb=prev_verb,
+                                 prev_treeconflict=prev_treeconflict)
 
     return cls('', desc)
 
@@ -499,6 +641,9 @@ class State:
     desc = { }
     for line in lines:
       if line.startswith('DBG:') or line.startswith('Transmitting'):
+        continue
+
+      if line.startswith('Committing transaction'):
         continue
 
       match = _re_parse_commit_ext.search(line)
@@ -513,13 +658,18 @@ class State:
     return cls('', desc)
 
   @classmethod
-  def from_wc(cls, base, load_props=False, ignore_svn=True):
+  def from_wc(cls, base, load_props=False, ignore_svn=True,
+              keep_eol_style=False):
     """Create a State object from a working copy.
 
     Walks the tree at PATH, building a State based on the actual files
     and directories found. If LOAD_PROPS is True, then the properties
     will be loaded for all nodes (Very Expensive!). If IGNORE_SVN is
     True, then the .svn subdirectories will be excluded from the State.
+
+    If KEEP_EOL_STYLE is set, don't let Python normalize the EOL when
+    reading working copy contents as text files.  It has no effect on
+    binary files.
     """
     if not base:
       # we're going to walk the base, and the OS wants "."
@@ -535,7 +685,22 @@ class State:
       for name in dirs + files:
         node = os.path.join(dirpath, name)
         if os.path.isfile(node):
-          contents = open(node, 'r').read()
+          try:
+            if keep_eol_style:
+              with io.open(node, 'r', newline='', encoding='utf-8') as fp:
+                contents = fp.read()
+            else:
+              with io.open(node, 'r', encoding='utf-8') as fp:
+                contents = fp.read()
+            if not isinstance(contents, str):
+              # Python 2: contents is read as an unicode object,
+              # but we expect it is a str.
+              contents = contents.encode()
+          except:
+            # If the file contains non UTF-8 character, we treat its
+            # content as binary represented as a bytes object.
+            with open(node, 'rb') as fp:
+              contents = fp.read()
         else:
           contents = None
         desc[repos_join(parent, name)] = StateItem(contents=contents)
@@ -577,23 +742,24 @@ class State:
           })
 
     desc = { }
-    dot_svn = svntest.main.get_admin_name()
+    dump_data = svntest.main.run_entriesdump_tree(base)
 
-    for dirpath in svntest.main.run_entriesdump_subdirs(base):
+    if not dump_data:
+      # Probably 'svn status' run on an actual only node
+      # ### Improve!
+      return cls('', desc)
 
-      if base == '.' and dirpath != '.':
-        dirpath = '.' + os.path.sep + dirpath
+    dirent_join = repos_join
+    if len(base) == 2 and base[1:]==':' and sys.platform=='win32':
+      # We have a win32 drive relative path... Auch. Fix joining
+      def drive_join(a, b):
+        if len(a) == 2:
+          return a+b
+        else:
+          return repos_join(a,b)
+      dirent_join = drive_join
 
-      entries = svntest.main.run_entriesdump(dirpath)
-      if entries is None:
-        continue
-
-      if dirpath == '.':
-        parent = ''
-      elif dirpath.startswith('.' + os.sep):
-        parent = to_relpath(dirpath[2:])
-      else:
-        parent = to_relpath(dirpath)
+    for parent, entries in sorted(dump_data.items()):
 
       parent_url = entries[''].url
 
@@ -606,16 +772,19 @@ class State:
         # entries that are ABSENT don't show up in status
         if entry.absent:
           continue
+        # entries that are User Excluded don't show up in status
+        if entry.depth == -1:
+          continue
         if name and entry.kind == 2:
           # stub subdirectory. leave a "missing" StateItem in here. note
           # that we can't put the status as "! " because that gets tweaked
           # out of our expected tree.
           item = StateItem(status='  ', wc_rev='?')
-          desc[repos_join(parent, name)] = item
+          desc[dirent_join(parent, name)] = item
           continue
         item = StateItem.from_entry(entry)
         if name:
-          desc[repos_join(parent, name)] = item
+          desc[dirent_join(parent, name)] = item
           implied_url = repos_join(parent_url, svn_uri_quote(name))
         else:
           item._url = entry.url  # attach URL to directory StateItems
@@ -631,6 +800,66 @@ class State:
         if implied_url and implied_url != entry.url:
           item.switched = 'S'
 
+        if entry.file_external:
+          item.switched = 'X'
+
+    return cls('', desc)
+
+  @classmethod
+  def from_eids(cls, lines):
+
+    # Need to read all elements in a branch before we can construct
+    # the full path to an element.
+    # For the full path we use <branch-id>/<path-within-branch>.
+
+    def eid_path(eids, eid):
+      ele = eids[eid]
+      if ele[0] == '-1':
+        return ele[1]
+      parent_path = eid_path(eids, ele[0])
+      if parent_path == '':
+        return ele[1]
+      return parent_path + '/' + ele[1]
+
+    def eid_full_path(eids, eid, branch_id):
+      path = eid_path(eids, eid)
+      if path == '':
+        return branch_id
+      return branch_id + '/' + path
+
+    def add_to_desc(eids, desc, branch_id):
+      for k, v in eids.items():
+        desc[eid_full_path(eids, k, branch_id)] = StateItem(eid=k)
+
+    branch_id = None
+    eids = {}
+    desc = {}
+    for line in lines:
+
+      match = _re_parse_eid_ele.search(line)
+      if match and match.group(2) != 'none':
+        eid = match.group(1)
+        parent_eid = match.group(3)
+        path = match.group(4)
+        if path == '.':
+          path = ''
+        eids[eid] = [parent_eid, path]
+
+      match = _re_parse_eid_branch.search(line)
+      if match:
+        if branch_id:
+          add_to_desc(eids, desc, branch_id)
+          eids = {}
+        branch_id = match.group(1)
+        root_eid = match.group(2)
+
+      match = _re_parse_eid_merge_history.search(line)
+      if match:
+        ### TODO: store the merge history
+        pass
+
+    add_to_desc(eids, desc, branch_id)
+
     return cls('', desc)
 
 
@@ -643,10 +872,12 @@ class StateItem:
   """
 
   def __init__(self, contents=None, props=None,
-               status=None, verb=None, wc_rev=None,
-               entry_rev=None, entry_status=None,
+               status=None, verb=None, wc_rev=None, entry_kind=None,
+               entry_rev=None, entry_status=None, entry_copied=None,
                locked=None, copied=None, switched=None, writelocked=None,
-               treeconflict=None):
+               treeconflict=None, moved_from=None, moved_to=None,
+               prev_status=None, prev_verb=None, prev_treeconflict=None,
+               eid=None):
     # provide an empty prop dict if it wasn't provided
     if props is None:
       props = { }
@@ -654,6 +885,8 @@ class StateItem:
     ### keep/make these ints one day?
     if wc_rev is not None:
       wc_rev = str(wc_rev)
+    if eid is not None:
+      eid = str(eid)
 
     # Any attribute can be None if not relevant, unless otherwise stated.
 
@@ -663,22 +896,33 @@ class StateItem:
     self.props = props
     # A two-character string from the first two columns of 'svn status'.
     self.status = status
+    self.prev_status = prev_status
     # The action word such as 'Adding' printed by commands like 'svn update'.
     self.verb = verb
+    self.prev_verb = prev_verb
     # The base revision number of the node in the WC, as a string.
     self.wc_rev = wc_rev
+    # If 'file' specifies that the node is a file, and as such has no svn_wc_entry_t
+    # descendants
+    self.entry_kind = None
     # These will be set when we expect the wc_rev/status to differ from those
     # found in the entries code.
     self.entry_rev = entry_rev
     self.entry_status = entry_status
+    self.entry_copied = entry_copied
     # For the following attributes, the value is the status character of that
     # field from 'svn status', except using value None instead of status ' '.
     self.locked = locked
     self.copied = copied
     self.switched = switched
     self.writelocked = writelocked
-    # Value 'C' or ' ', or None as an expected status meaning 'do not check'.
+    # Value 'C', 'A', 'D' or ' ', or None as an expected status meaning 'do not check'.
     self.treeconflict = treeconflict
+    self.prev_treeconflict = prev_treeconflict
+    # Relative paths to the move locations
+    self.moved_from = moved_from
+    self.moved_to = moved_to
+    self.eid = eid
 
   def copy(self):
     "Make a deep copy of self."
@@ -692,21 +936,22 @@ class StateItem:
       # Refine the revision args (for now) to ensure they are strings.
       if value is not None and name == 'wc_rev':
         value = str(value)
+      if value is not None and name == 'eid':
+        value = str(value)
       setattr(self, name, value)
 
   def __eq__(self, other):
     if not isinstance(other, StateItem):
       return False
     v_self = dict([(k, v) for k, v in vars(self).items()
-                   if not k.startswith('_')])
+                   if not k.startswith('_') and not k.startswith('entry_')])
     v_other = dict([(k, v) for k, v in vars(other).items()
-                    if not k.startswith('_')])
-    if self.treeconflict is None:
-      v_other = v_other.copy()
-      v_other['treeconflict'] = None
-    if other.treeconflict is None:
-      v_self = v_self.copy()
-      v_self['treeconflict'] = None
+                    if not k.startswith('_') and not k.startswith('entry_')])
+
+    if self.wc_rev == '0' and self.status == 'A ':
+      v_self['wc_rev'] = '-'
+    if other.wc_rev == '0' and other.status == 'A ':
+      v_other['wc_rev'] = '-'
     return v_self == v_other
 
   def __ne__(self, other):
@@ -716,8 +961,12 @@ class StateItem:
     atts = { }
     if self.status is not None:
       atts['status'] = self.status
+    if self.prev_status is not None:
+      atts['prev_status'] = self.prev_status
     if self.verb is not None:
       atts['verb'] = self.verb
+    if self.prev_verb is not None:
+      atts['prev_verb'] = self.prev_verb
     if self.wc_rev is not None:
       atts['wc_rev'] = self.wc_rev
     if self.locked is not None:
@@ -730,6 +979,14 @@ class StateItem:
       atts['writelocked'] = self.writelocked
     if self.treeconflict is not None:
       atts['treeconflict'] = self.treeconflict
+    if self.prev_treeconflict is not None:
+      atts['prev_treeconflict'] = self.prev_treeconflict
+    if self.moved_from is not None:
+      atts['moved_from'] = self.moved_from
+    if self.moved_to is not None:
+      atts['moved_to'] = self.moved_to
+    if self.eid is not None:
+      atts['eid'] = self.eid
 
     return (os.path.normpath(path), self.contents, self.props, atts)
 
@@ -827,18 +1084,25 @@ def repos_join(base, path):
   """Join two repos paths. This generally works for URLs too."""
   if base == '':
     return path
-  if path == '':
+  elif path == '':
     return base
-  return base + '/' + path
+  elif base[len(base)-1:] == '/':
+    return base + path
+  else:
+    return base + '/' + path
 
 
 def svn_uri_quote(url):
   # svn defines a different set of "safe" characters than Python does, so
   # we need to avoid escaping them. see subr/path.c:uri_char_validity[]
-  return urllib.quote(url, "!$&'()*+,-./:=@_~")
+  return urllib_quote(url, "!$&'()*+,-./:=@_~")
 
 
 # ------------
+
+def python_sqlite_can_read_wc():
+  """Check if the Python builtin is capable enough to peek into wc.db"""
+  return svntest.main.python_sqlite_can_read_our_wc_db()
 
 def open_wc_db(local_path):
   """Open the SQLite DB for the WC path LOCAL_PATH.
@@ -885,6 +1149,24 @@ def text_base_path(file_path):
     return fn + ".svn-base"
 
   raise svntest.Failure("No pristine text for " + relpath)
+
+def sqlite_stmt(wc_root_path, stmt):
+  """Execute STMT on the SQLite wc.db in WC_ROOT_PATH and return the
+     results."""
+
+  db = open_wc_db(wc_root_path)[0]
+  c = db.cursor()
+  c.execute(stmt)
+  return c.fetchall()
+
+def sqlite_exec(wc_root_path, stmt):
+  """Execute STMT on the SQLite wc.db in WC_ROOT_PATH and return the
+     results."""
+
+  db = open_wc_db(wc_root_path)[0]
+  c = db.cursor()
+  c.execute(stmt)
+  db.commit()
 
 
 # ------------


### PR DESCRIPTION
* svntest/__init__.py, svntest/actions.py, svntest/factory.py,
  svntest/main.py, svntest/objects.py, svntest/sandbox.py,
  svntest/testcase.py, svntest/tree.py, svntest/verify.py,
  svntest/wc.py:
    Update the svntest subdirectory from

      http://svn.apache.org/repos/asf/subversion/trunk/subversion/tests/cmdline/svntest

    using svntest/update.sh.  Adjust run-tests.py for changes in svntest.

* runtest.py:
  - Adjust required version of Python 2.
  - Get the minor version of installed svn program and set it to
    svntest.main.SVN_VER_MINOR. This allows at least Subversion >= 1.9
    to run the test suites.